### PR TITLE
Enables AppVeyor Caching

### DIFF
--- a/Source/ExampleApp.Test.Functional/Models/ExampleAppPages/SlinqyExampleWebPage.cs
+++ b/Source/ExampleApp.Test.Functional/Models/ExampleAppPages/SlinqyExampleWebPage.cs
@@ -18,7 +18,8 @@
         /// </summary>
         /// <param name="webBrowserDriver">Specifies the IWebDriver to use for controlling the browser.</param>
         /// <param name="webpageRelativePath">Specifies the relative path of the web page.</param>
-        protected SlinqyExampleWebpage(
+        protected 
+        SlinqyExampleWebpage(
             IWebDriver webBrowserDriver,
             Uri        webpageRelativePath) : base(webBrowserDriver, webpageRelativePath)
         {

--- a/Source/ExampleApp.Test.Functional/Models/WebBrowser.cs
+++ b/Source/ExampleApp.Test.Functional/Models/WebBrowser.cs
@@ -98,7 +98,8 @@
         /// Remember that it is possible to end up on a web page that is different than what was requested by TPage.
         /// </returns>
         public
-        TPage NavigateTo<TPage>() where TPage : Webpage
+        TPage 
+        NavigateTo<TPage>() where TPage : Webpage
         {
             var relativeUri = WellKnownPages.Single(pair => pair.Value == typeof(TPage)).Key;
 
@@ -121,7 +122,9 @@
         /// If the current Webpage is of type TPage, then an instance of Webpage modeling TPage will be returned.
         /// Otherwise, null will be returned.
         /// </returns>
-        public TPage GetCurrentPageAs<TPage>() where TPage : Webpage
+        public 
+        TPage 
+        GetCurrentPageAs<TPage>() where TPage : Webpage
         {
             var uri = new Uri(this.webBrowserDriver.Url);
             var path = uri.AbsolutePath;
@@ -139,7 +142,9 @@
         /// <summary>
         /// Frees any resources allocated by this instance.
         /// </summary>
-        public void Dispose()
+        public 
+        void 
+        Dispose()
         {
             this.webBrowserDriver.Dispose();
         }

--- a/Source/ExampleApp.Test.Functional/Models/WebPage.cs
+++ b/Source/ExampleApp.Test.Functional/Models/WebPage.cs
@@ -18,7 +18,8 @@
         /// </summary>
         /// <param name="webBrowserDriver">Specifies the driver to use for controlling the browser.</param>
         /// <param name="webpageRelativePath">Specifies the relative path of this web page.</param>
-        protected Webpage(
+        protected 
+        Webpage(
             IWebDriver  webBrowserDriver,
             Uri         webpageRelativePath) : base(webBrowserDriver)
         {

--- a/Source/ExampleApp.Test.Functional/Setup.cs
+++ b/Source/ExampleApp.Test.Functional/Setup.cs
@@ -70,7 +70,9 @@
         /// <summary>
         /// Disposes resources.
         /// </summary>
-        public void Dispose()
+        public 
+        void 
+        Dispose()
         {
             this.webBrowser.Dispose();
         }

--- a/Source/ExampleApp.Test.Functional/Steps/NavigationSteps.cs
+++ b/Source/ExampleApp.Test.Functional/Steps/NavigationSteps.cs
@@ -30,7 +30,9 @@
         /// Navigates to the Example App Homepage.
         /// </summary>
         [Given]
-        public void GivenINavigateToTheHomepage()
+        public 
+        void 
+        GivenINavigateToTheHomepage()
         {
             // Attempt to navigate to the Home page.
             this.webBrowser.NavigateTo<Homepage>(); 

--- a/Source/ExampleApp.Test.Functional/Steps/VersionSteps.cs
+++ b/Source/ExampleApp.Test.Functional/Steps/VersionSteps.cs
@@ -21,7 +21,9 @@
         /// Initializes a new instance with a web browser.
         /// </summary>
         /// <param name="webBrowser">Specifies the browser.</param>
-        public VersionSteps(WebBrowser webBrowser)
+        public 
+        VersionSteps(
+            WebBrowser webBrowser)
         {
             this.webBrowser = webBrowser;
         }
@@ -32,7 +34,9 @@
         /// ensuring they were both built from the same source code.
         /// </summary>
         [Then]
-        public void ThenTheApplicationVersionMatchesTheTestVersion()
+        public 
+        void 
+        ThenTheApplicationVersionMatchesTheTestVersion()
         {
             var examplePage = this.webBrowser.GetCurrentPageAs<SlinqyExampleWebpage>();
 

--- a/Source/ExampleApp/App_Start/RouteConfig.cs
+++ b/Source/ExampleApp/App_Start/RouteConfig.cs
@@ -12,7 +12,11 @@
         /// Applies routes to the specified RouteCollection.
         /// </summary>
         /// <param name="routes">Specifies the RouteCollection to configure.</param>
-        public static void RegisterRoutes(RouteCollection routes)
+        public 
+        static 
+        void 
+        RegisterRoutes(
+            RouteCollection routes)
         {
             routes.IgnoreRoute("{resource}.axd/{*pathInfo}");
 

--- a/Source/ExampleApp/Controllers/HomeController.cs
+++ b/Source/ExampleApp/Controllers/HomeController.cs
@@ -11,7 +11,9 @@
         /// Handles the default HTTP GET /.
         /// </summary>
         /// <returns>Returns the default Homepage view.</returns>
-        public ActionResult Index()
+        public 
+        ActionResult 
+        Index()
         {
             this.ViewBag.Title = "Home Page";
 

--- a/Source/ExampleApp/Global.asax.cs
+++ b/Source/ExampleApp/Global.asax.cs
@@ -13,7 +13,9 @@
         /// This method is automatically called when the application first starts.
         /// </summary>
         [SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "ASP.NET will not call this method if it is static.")]
-        protected void Application_Start()
+        protected 
+        void 
+        Application_Start()
         {
             AreaRegistration.RegisterAllAreas();
             RouteConfig.RegisterRoutes(RouteTable.Routes);

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,5 +16,4 @@ test: off
 
 cache:
   - .\Source\packages -> .\Source\ExampleApp\packages.config
-  - .\Source\packages -> .\Source\ExampleApp.Test.Functional\packages.config
   - C:\Users\appveyor\AppData\Roaming\Windows Azure Powershell\AzureDataCollectionProfile.json

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,3 +17,4 @@ test: off
 cache:
   - .\Source\packages -> .\Source\ExampleApp\packages.config
   - .\Source\packages -> .\Source\ExampleApp.Test.Functional\packages.config
+  - C:\Users\appveyor\AppData\Roaming\Windows Azure Powershell\AzureDataCollectionProfile.json

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,3 +13,6 @@ deploy_script:
   - ps: .\CI "Deploy,FunctionalTest"
 
 test: off
+
+cache:
+  - .\Source\packages -> .\Source\ExampleApp\packages.config  # preserve "packages" directory in the root of build folder but will reset it if packages.config is modified

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,4 +15,5 @@ deploy_script:
 test: off
 
 cache:
-  - .\Source\packages -> .\Source\ExampleApp\packages.config  # preserve "packages" directory in the root of build folder but will reset it if packages.config is modified
+  - .\Source\packages -> .\Source\ExampleApp\packages.config
+  - .\Source\packages -> .\Source\ExampleApp.Test.Functional\packages.config


### PR DESCRIPTION
Configures AppVeyor to cache the NuGet packages folder so that the same files don't have to be retrieved on each build.

Also caches the Azure PowerShell profile file that instructs Azure PowerShell to disable data collection so that the prompt asking the user doesn't appear.