### PR TITLE
Re-enables StyleCop

### DIFF
--- a/Source/ExampleApp.Web/Controllers/SlinqyQueueController.cs
+++ b/Source/ExampleApp.Web/Controllers/SlinqyQueueController.cs
@@ -35,9 +35,8 @@
         /// Tracks the last created queue.
         /// This currently does not support running multiple instances of the website.
         /// </summary>
-        // TODO: Modify to support running on multiple instances.
         [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "Storing statically until proper DI is available.")]
-        private static SlinqyAgent slinqyAgent;
+        private static SlinqyAgent slinqyAgent; // TODO: Modify to support running on multiple instances.
 
         /// <summary>
         /// Handles HTTP GET /api/slinqy-queue/{queueName} by returning information about the requested queue.

--- a/Source/ExampleApp.Web/ExampleApp.Web.csproj
+++ b/Source/ExampleApp.Web/ExampleApp.Web.csproj
@@ -232,5 +232,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\StyleCop.Analyzers.1.0.0-beta015\build\StyleCop.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\StyleCop.Analyzers.1.0.0-beta015\build\StyleCop.Analyzers.targets'))" />
+    <Error Condition="!Exists('..\packages\Visual-StyleCop.MSBuild.4.7.58.3\build\Visual-StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Visual-StyleCop.MSBuild.4.7.58.3\build\Visual-StyleCop.MSBuild.Targets'))" />
   </Target>
+  <Import Project="..\packages\Visual-StyleCop.MSBuild.4.7.58.3\build\Visual-StyleCop.MSBuild.Targets" Condition="Exists('..\packages\Visual-StyleCop.MSBuild.4.7.58.3\build\Visual-StyleCop.MSBuild.Targets')" />
 </Project>

--- a/Source/ExampleApp.Web/Global.asax.cs
+++ b/Source/ExampleApp.Web/Global.asax.cs
@@ -3,6 +3,7 @@
     "SA1649:FileHeaderFileNameDocumentationMustMatchTypeName",
     Justification = "Can't get Global.asax to match the class name."
 )]
+
 namespace ExampleApp.Web
 {
     using System.Diagnostics.CodeAnalysis;

--- a/Source/ExampleApp.Web/Models/ServiceBusQueueModel.cs
+++ b/Source/ExampleApp.Web/Models/ServiceBusQueueModel.cs
@@ -11,6 +11,9 @@
     /// </summary>
     public class ServiceBusQueueModel : IPhysicalQueue
     {
+        /// <summary>
+        /// The client to the Azure Service Bus Queue.
+        /// </summary>
         private readonly QueueClient queueClient;
 
         /// <summary>
@@ -57,7 +60,7 @@
         public long CurrentSizeBytes { get; }
 
         /// <summary>
-        /// Gets a boolean value that indicates if the queue is writable (true) or not (false).
+        /// Gets a value indicating whether the queue is writable (true) or not (false).
         /// </summary>
         public bool Writable { get; }
 

--- a/Source/ExampleApp.Web/packages.config
+++ b/Source/ExampleApp.Web/packages.config
@@ -20,6 +20,7 @@
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net46" />
   <package id="psake" version="4.4.2" targetFramework="net46" />
   <package id="StyleCop.Analyzers" version="1.0.0-beta015" targetFramework="net46" developmentDependency="true" />
+  <package id="Visual-StyleCop.MSBuild" version="4.7.58.3" targetFramework="net46" />
   <package id="WebGrease" version="1.6.0" targetFramework="net46" />
   <package id="WindowsAzure.ServiceBus" version="3.0.6" targetFramework="net46" />
 </packages>

--- a/Source/Scripts/CI.Tasks.ps1
+++ b/Source/Scripts/CI.Tasks.ps1
@@ -222,21 +222,22 @@ Task FunctionalTest -depends LoadSettings -description 'Tests that the required 
 }
 
 Task DestroyEnvironment -depends LoadSettings -description "Permanently deletes and removes all services and data from the target environment." {
-    # Make sure we're authenticated with Azure so the script can deploy.
-    GetOrLogin-AzureRmContext `
+    # Make sure we're authenticated with Azure.
+    $context = GetOrLogin-AzureRmContext `
         -AzureDeployUser $env:AzureDeployUser `
-        -AzureDeployPass $env:AzureDeployPass |
-            Out-Null
+        -AzureDeployPass $env:AzureDeployPass
+
+    $subscriptionName = $context.Subscription.SubscriptionName
 
     if (-not (Check-AzureResourceGroupExists $Settings.ResourceGroupName)) {
-        Write-Host "The resource group $($Settings.ResourceGroupName) doesn't exist, nothing to delete..."
+        Write-Host "The resource group $($Settings.ResourceGroupName) doesn't exist in Azure Subscription $subscriptionName, nothing to delete..."
         return
     }
 
     $answer = Read-Host `
-        -Prompt "Are you use you want to permanently delete all services and data from the target environment $($Settings.EnvironmentName)? (y/n)"
+        -Prompt "Are you use you want to permanently delete all services and data from the target environment $($Settings.EnvironmentName) in Azure Subscription $subscriptionName? (y/n)"
 
-    if ($answer -eq 'y'){
+    if ($answer -eq 'y') {
         Remove-AzureRmResourceGroup `
             -Name $Settings.ResourceGroupName `
             -Force

--- a/Source/Scripts/CI.Tasks.ps1
+++ b/Source/Scripts/CI.Tasks.ps1
@@ -90,7 +90,7 @@ Task Build -depends Clean -description "Compiles all source code." {
 
     $currentDir = Get-Location
     Set-Location $ArtifactsPath
-    exec { . $OpenCoverPath -target:$XUnitPath -targetargs:$TestDlls -register:user -output:$OpenCoverOutputPath -filter:'+[Slinqy.Core]*' }
+    exec { . $OpenCoverPath -target:$XUnitPath -targetargs:$TestDlls -returntargetcode -register:user -output:$OpenCoverOutputPath -filter:'+[Slinqy.Core]*' }
     Set-Location $currentDir
 
     $ReportGeneratorPath       = Join-Path $SourcePath 'packages\ReportGenerator.2.3.2.0\tools\ReportGenerator.exe'

--- a/Source/Settings.StyleCop
+++ b/Source/Settings.StyleCop
@@ -90,6 +90,11 @@
             <BooleanProperty Name="Enabled">False</BooleanProperty>
           </RuleSettings>
         </Rule>
+        <Rule Name="CurlyBracketsForMultiLineStatementsMustNotShareLine">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
       </Rules>
       <AnalyzerSettings />
     </Analyzer>

--- a/Source/Slinqy.Core.Test.Unit/Slinqy.Core.Test.Unit.csproj
+++ b/Source/Slinqy.Core.Test.Unit/Slinqy.Core.Test.Unit.csproj
@@ -121,7 +121,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\StyleCop.Analyzers.1.0.0-beta015\build\StyleCop.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\StyleCop.Analyzers.1.0.0-beta015\build\StyleCop.Analyzers.targets'))" />
+    <Error Condition="!Exists('..\packages\Visual-StyleCop.MSBuild.4.7.58.3\build\Visual-StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Visual-StyleCop.MSBuild.4.7.58.3\build\Visual-StyleCop.MSBuild.Targets'))" />
   </Target>
+  <Import Project="..\packages\Visual-StyleCop.MSBuild.4.7.58.3\build\Visual-StyleCop.MSBuild.Targets" Condition="Exists('..\packages\Visual-StyleCop.MSBuild.4.7.58.3\build\Visual-StyleCop.MSBuild.Targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Source/Slinqy.Core.Test.Unit/SlinqyQueueClientTests.cs
+++ b/Source/Slinqy.Core.Test.Unit/SlinqyQueueClientTests.cs
@@ -10,7 +10,14 @@
     /// </summary>
     public class SlinqyQueueClientTests
     {
+        /// <summary>
+        /// The instance under test.
+        /// </summary>
         private readonly SlinqyQueueClient client;
+
+        /// <summary>
+        /// The fake that simulates a physical queue service.
+        /// </summary>
         private readonly IPhysicalQueueService fakePhysicalQueueService = A.Fake<IPhysicalQueueService>();
 
         /// <summary>
@@ -44,10 +51,10 @@
         CreateAsync_QueueNameValid_CreateDelegateInvoked()
         {
             // Arrange
-            const string queueName = "test";
+            const string QueueName = "test";
 
             // Act
-            await this.client.CreateAsync(queueName);
+            await this.client.CreateAsync(QueueName);
 
             // Assert
             A.CallTo(() =>
@@ -83,13 +90,13 @@
         Get_SlinqyQueueDoesNotExistInCollection_IsReturned()
         {
             // Arrange
-            const string queueName = "test";
+            const string QueueName = "test";
 
             // Act
-            var actualQueueName = this.client.Get(queueName).Name;
+            var actualQueueName = this.client.Get(QueueName).Name;
 
             // Assert
-            Assert.Equal(queueName, actualQueueName);
+            Assert.Equal(QueueName, actualQueueName);
         }
     }
 }

--- a/Source/Slinqy.Core.Test.Unit/SlinqyQueueShardMonitorTests.cs
+++ b/Source/Slinqy.Core.Test.Unit/SlinqyQueueShardMonitorTests.cs
@@ -11,10 +11,20 @@
     /// </summary>
     public class SlinqyQueueShardMonitorTests
     {
+        /// <summary>
+        /// Represents a valid value where one is needed for a Slinqy queue name parameters.
+        /// Should not be a special value other than it is guaranteed to be valid.
+        /// </summary>
         private const string ValidSlinqyQueueName = "queue-name";
 
+        /// <summary>
+        /// The fake that simulates a physical queue service.
+        /// </summary>
         private readonly IPhysicalQueueService fakeQueueService = A.Fake<IPhysicalQueueService>();
 
+        /// <summary>
+        /// The instance under test.
+        /// </summary>
         private readonly SlinqyQueueShardMonitor monitor;
 
         /// <summary>

--- a/Source/Slinqy.Core.Test.Unit/SlinqyQueueShardTests.cs
+++ b/Source/Slinqy.Core.Test.Unit/SlinqyQueueShardTests.cs
@@ -11,8 +11,15 @@
     /// </summary>
     public class SlinqyQueueShardTests
     {
+        /// <summary>
+        /// Represents a valid value where one is needed for a Slinqy shard name parameters.
+        /// Should not be a special value other than it is guaranteed to be valid.
+        /// </summary>
         private const string ValidSlinqyShardName = "queue-name-0";
 
+        /// <summary>
+        /// The fake that simulates a physical queue.
+        /// </summary>
         private readonly IPhysicalQueue fakePhysicalQueue = A.Fake<IPhysicalQueue>();
 
         /// <summary>

--- a/Source/Slinqy.Core.Test.Unit/SlinqyQueueTests.cs
+++ b/Source/Slinqy.Core.Test.Unit/SlinqyQueueTests.cs
@@ -10,14 +10,26 @@
     /// </summary>
     public class SlinqyQueueTests
     {
+        /// <summary>
+        /// Represents a valid value where one is needed for a Slinqy queue name parameters.
+        /// Should not be a special value other than it is guaranteed to be valid.
+        /// </summary>
         private const string ValidSlinqyQueueName = "queue-name";
 
+        /// <summary>
+        /// The fake that simulates a physical queue service.
+        /// </summary>
         private readonly IPhysicalQueueService fakePhysicalQueueService = A.Fake<IPhysicalQueueService>();
 
+        /// <summary>
+        /// The fake that simulates a read-only physical queue.
+        /// </summary>
         private readonly IPhysicalQueue fakeReadOnlyPhysicalQueue = A.Fake<IPhysicalQueue>();
-        private readonly IPhysicalQueue fakeWritablePhysicalQueue = A.Fake<IPhysicalQueue>();
 
-        private readonly List<IPhysicalQueue> fakeShards;
+        /// <summary>
+        /// The fake that simulates a writable physical queue.
+        /// </summary>
+        private readonly IPhysicalQueue fakeWritablePhysicalQueue = A.Fake<IPhysicalQueue>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SlinqyQueueTests"/> class.
@@ -25,7 +37,7 @@
         public
         SlinqyQueueTests()
         {
-            this.fakeShards = new List<IPhysicalQueue> {
+            var fakeShards = new List<IPhysicalQueue> {
                 this.fakeReadOnlyPhysicalQueue,
                 this.fakeWritablePhysicalQueue
             };
@@ -38,7 +50,7 @@
 
             A.CallTo(() =>
                 this.fakePhysicalQueueService.ListQueues(A<string>.Ignored)
-            ).Returns(this.fakeShards);
+            ).Returns(fakeShards);
         }
 
         /// <summary>

--- a/Source/Slinqy.Core.Test.Unit/packages.config
+++ b/Source/Slinqy.Core.Test.Unit/packages.config
@@ -5,6 +5,7 @@
   <package id="OpenCover" version="4.6.166" targetFramework="net46" />
   <package id="ReportGenerator" version="2.3.2.0" targetFramework="net46" />
   <package id="StyleCop.Analyzers" version="1.0.0-beta015" targetFramework="net46" developmentDependency="true" />
+  <package id="Visual-StyleCop.MSBuild" version="4.7.58.3" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />

--- a/Source/Slinqy.Core/IPhysicalQueue.cs
+++ b/Source/Slinqy.Core/IPhysicalQueue.cs
@@ -28,7 +28,7 @@
         long CurrentSizeBytes { get; }
 
         /// <summary>
-        /// Gets a boolean value that indicates if the queue is writable (true) or not (false).
+        /// Gets a value indicating whether the queue is writable (true) or not (false).
         /// </summary>
         bool Writable { get; }
 

--- a/Source/Slinqy.Core/Slinqy.Core.csproj
+++ b/Source/Slinqy.Core/Slinqy.Core.csproj
@@ -65,7 +65,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\StyleCop.Analyzers.1.0.0-beta015\build\StyleCop.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\StyleCop.Analyzers.1.0.0-beta015\build\StyleCop.Analyzers.targets'))" />
+    <Error Condition="!Exists('..\packages\Visual-StyleCop.MSBuild.4.7.58.3\build\Visual-StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Visual-StyleCop.MSBuild.4.7.58.3\build\Visual-StyleCop.MSBuild.Targets'))" />
   </Target>
+  <Import Project="..\packages\Visual-StyleCop.MSBuild.4.7.58.3\build\Visual-StyleCop.MSBuild.Targets" Condition="Exists('..\packages\Visual-StyleCop.MSBuild.4.7.58.3\build\Visual-StyleCop.MSBuild.Targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Source/Slinqy.Core/SlinqyQueue.cs
+++ b/Source/Slinqy.Core/SlinqyQueue.cs
@@ -26,7 +26,7 @@
         /// </summary>
         /// <param name="queueName">The name of the queue.</param>
         /// <param name="physicalQueueService">
-        /// Specifies the IPhsicalQueueService to use for managing queue resources.
+        /// Specifies the IPhysicalQueueService to use for managing queue resources.
         /// </param>
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "This rule was not designed for async calls.")]
         public

--- a/Source/Slinqy.Core/SlinqyQueueShard.cs
+++ b/Source/Slinqy.Core/SlinqyQueueShard.cs
@@ -11,10 +11,26 @@
     /// </summary>
     public class SlinqyQueueShard
     {
+        /// <summary>
+        /// Specifies a regular expression that can extract the index number from a given queue shard name.
+        /// This expression will use all numerical characters found at the end of the name as the index value.
+        /// For example, all the following should work:
+        /// my-queue1234
+        /// my-queue-1234
+        /// my1queue1234
+        /// my1queue-1234
+        /// And return 1234 as the index.
+        /// </summary>
         private const string ShardIndexRegularExpression = @"\d+$";
 
+        /// <summary>
+        /// Instantiates the regular expression as a .NET Regex instance.
+        /// </summary>
         private static readonly Regex ShardIndexRegEx = new Regex(ShardIndexRegularExpression, RegexOptions.Compiled);
 
+        /// <summary>
+        /// The physical queue underlying this shard.
+        /// </summary>
         private readonly IPhysicalQueue physicalQueue;
 
         /// <summary>

--- a/Source/Slinqy.Core/SlinqyQueueShardMonitor.cs
+++ b/Source/Slinqy.Core/SlinqyQueueShardMonitor.cs
@@ -9,8 +9,19 @@
     /// </summary>
     public class SlinqyQueueShardMonitor
     {
+        /// <summary>
+        /// The name of the Slinqy queue being monitored.
+        /// </summary>
         private string                  queueName;
+
+        /// <summary>
+        /// The physical queue service hosting the Slinqy queue.
+        /// </summary>
         private IPhysicalQueueService   queueService;
+
+        /// <summary>
+        /// The async Task that is running the queue polling operations.
+        /// </summary>
         private Task                    pollQueuesTask;
 
         /// <summary>
@@ -58,6 +69,10 @@
             var awaitResult = this.pollQueuesTask.ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Updates the instances Shards collection based on the latest data from the physical queue service.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         private
         async Task
         UpdateShards()

--- a/Source/Slinqy.Core/packages.config
+++ b/Source/Slinqy.Core/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="StyleCop.Analyzers" version="1.0.0-beta015" targetFramework="net46" developmentDependency="true" />
+  <package id="Visual-StyleCop.MSBuild" version="4.7.58.3" targetFramework="net46" />
 </packages>

--- a/Source/Slinqy.Test.Functional/Models/ExampleAppPages/QueueClientSection.cs
+++ b/Source/Slinqy.Test.Functional/Models/ExampleAppPages/QueueClientSection.cs
@@ -8,6 +8,10 @@
     /// </summary>
     public class QueueClientSection : SeleniumWebBase
     {
+        /// <summary>
+        /// A proxy reference to the element in the web browser.
+        /// </summary>
+        /// <remarks>This field is automatically populated by SpecFlow.</remarks>
         [FindsBy(How = How.Id, Using = "FillQueueButton")]
         private IWebElement fillQueueButton = null;
 

--- a/Source/Slinqy.Test.Functional/Slinqy.Test.Functional.csproj
+++ b/Source/Slinqy.Test.Functional/Slinqy.Test.Functional.csproj
@@ -180,8 +180,10 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
     <Error Condition="!Exists('..\packages\StyleCop.Analyzers.1.0.0-beta015\build\StyleCop.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\StyleCop.Analyzers.1.0.0-beta015\build\StyleCop.Analyzers.targets'))" />
+    <Error Condition="!Exists('..\packages\Visual-StyleCop.MSBuild.4.7.58.3\build\Visual-StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Visual-StyleCop.MSBuild.4.7.58.3\build\Visual-StyleCop.MSBuild.Targets'))" />
   </Target>
   <Import Project="..\packages\StyleCop.Analyzers.1.0.0-beta015\build\StyleCop.Analyzers.targets" Condition="Exists('..\packages\StyleCop.Analyzers.1.0.0-beta015\build\StyleCop.Analyzers.targets')" />
+  <Import Project="..\packages\Visual-StyleCop.MSBuild.4.7.58.3\build\Visual-StyleCop.MSBuild.Targets" Condition="Exists('..\packages\Visual-StyleCop.MSBuild.4.7.58.3\build\Visual-StyleCop.MSBuild.Targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Source/Slinqy.Test.Functional/packages.config
+++ b/Source/Slinqy.Test.Functional/packages.config
@@ -6,6 +6,7 @@
   <package id="SpecFlow" version="1.9.0" targetFramework="net46" />
   <package id="SpecFlow.xUnit" version="1.0.2" targetFramework="net46" />
   <package id="StyleCop.Analyzers" version="1.0.0-beta015" targetFramework="net46" developmentDependency="true" />
+  <package id="Visual-StyleCop.MSBuild" version="4.7.58.3" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,11 @@ os: Visual Studio 2015
 
 version: 0.1.{build}
 
+install:
+- ps: .\Source\Scripts\CI.InstallSystemPrereqs.ps1
+
 build_script:
-  - ps: .\Source\Scripts\CI.InstallSystemPrereqs.ps1;.\CI Build
+- ps: .\CI Build
 
 deploy_script:
   - ps: .\CI Deploy FunctionalTest


### PR DESCRIPTION
During the upgrade from the previous version of C# to version 6, the old StyleCop tool we were using did not support some of the new C# 6 features.  So we switched to Visual StyleCop which does, however inadvertently lost the configuration for having it run after each build.

Some time passed before this was realized, and so a number of issues have accumulated, and are now fixed.