### PR TITLE
Handle Many Shards

### DIFF
--- a/Source/CustomDictionary.xml
+++ b/Source/CustomDictionary.xml
@@ -4,6 +4,8 @@
     <Recognized>
       <Word>Slinqy</Word>
       <Word>API</Word>
+      <Word>enqueuing</Word>
+      <Word>dequeuing</Word>
     </Recognized>
   </Words>
 </Dictionary>

--- a/Source/ExampleApp.Web/Controllers/SlinqyQueueController.cs
+++ b/Source/ExampleApp.Web/Controllers/SlinqyQueueController.cs
@@ -82,8 +82,6 @@
                 PhysicalQueueService
             );
 
-            await monitor.Start();
-
             slinqyAgent = new SlinqyAgent(
                 PhysicalQueueService,
                 monitor,

--- a/Source/ExampleApp.Web/Models/ServiceBusQueueModel.cs
+++ b/Source/ExampleApp.Web/Models/ServiceBusQueueModel.cs
@@ -42,6 +42,8 @@
                                         EntityStatus.Active,
                                         EntityStatus.ReceiveDisabled
                                     }.Any(s => s == queueDescription.Status);
+            this.ReadWritable       = queueDescription.Status == EntityStatus.Active;
+            this.Disabled           = queueDescription.Status == EntityStatus.Disabled;
         }
 
         /// <summary>
@@ -63,6 +65,16 @@
         /// Gets a value indicating whether the queue is writable (true) or not (false).
         /// </summary>
         public bool Writable { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the queue supports both reading and writing (true) or not (false).
+        /// </summary>
+        public bool ReadWritable { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the queue is disabled for both reading and writing (true), or not (false).
+        /// </summary>
+        public bool Disabled { get; }
 
         /// <summary>
         /// Sends a batch of messages to the queue in a single transaction.

--- a/Source/ExampleApp.Web/Models/ServiceBusQueueModel.cs
+++ b/Source/ExampleApp.Web/Models/ServiceBusQueueModel.cs
@@ -42,8 +42,10 @@
                                         EntityStatus.Active,
                                         EntityStatus.ReceiveDisabled
                                     }.Any(s => s == queueDescription.Status);
-            this.IsReceiveEnabled   = queueDescription.Status == EntityStatus.Active;
-            this.Disabled           = queueDescription.Status == EntityStatus.Disabled;
+            this.IsReceiveEnabled   = new[] {
+                                        EntityStatus.Active,
+                                        EntityStatus.SendDisabled
+                                    }.Any(s => s == queueDescription.Status);
         }
 
         /// <summary>
@@ -70,11 +72,6 @@
         /// Gets a value indicating whether the queue supports both reading and writing (true) or not (false).
         /// </summary>
         public bool IsReceiveEnabled { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether the queue is disabled for both reading and writing (true), or not (false).
-        /// </summary>
-        public bool Disabled { get; }
 
         /// <summary>
         /// Sends a batch of messages to the queue in a single transaction.

--- a/Source/ExampleApp.Web/Models/ServiceBusQueueModel.cs
+++ b/Source/ExampleApp.Web/Models/ServiceBusQueueModel.cs
@@ -42,7 +42,7 @@
                                         EntityStatus.Active,
                                         EntityStatus.ReceiveDisabled
                                     }.Any(s => s == queueDescription.Status);
-            this.ReadWritable       = queueDescription.Status == EntityStatus.Active;
+            this.IsReceiveEnabled   = queueDescription.Status == EntityStatus.Active;
             this.Disabled           = queueDescription.Status == EntityStatus.Disabled;
         }
 
@@ -69,7 +69,7 @@
         /// <summary>
         /// Gets a value indicating whether the queue supports both reading and writing (true) or not (false).
         /// </summary>
-        public bool ReadWritable { get; }
+        public bool IsReceiveEnabled { get; }
 
         /// <summary>
         /// Gets a value indicating whether the queue is disabled for both reading and writing (true), or not (false).

--- a/Source/ExampleApp.Web/Models/ServiceBusQueueModel.cs
+++ b/Source/ExampleApp.Web/Models/ServiceBusQueueModel.cs
@@ -38,7 +38,7 @@
             this.Name               = queueDescription.Path;
             this.MaxSizeMegabytes   = queueDescription.MaxSizeInMegabytes;
             this.CurrentSizeBytes   = queueDescription.SizeInBytes;
-            this.Writable           = new[] {
+            this.IsSendEnabled      = new[] {
                                         EntityStatus.Active,
                                         EntityStatus.ReceiveDisabled
                                     }.Any(s => s == queueDescription.Status);
@@ -64,7 +64,7 @@
         /// <summary>
         /// Gets a value indicating whether the queue is writable (true) or not (false).
         /// </summary>
-        public bool Writable { get; }
+        public bool IsSendEnabled { get; }
 
         /// <summary>
         /// Gets a value indicating whether the queue supports both reading and writing (true) or not (false).

--- a/Source/ExampleApp.Web/Models/ServiceBusQueueServiceModel.cs
+++ b/Source/ExampleApp.Web/Models/ServiceBusQueueServiceModel.cs
@@ -105,6 +105,40 @@
         }
 
         /// <summary>
+        /// Sets the specified Service Bus queue in to a Disabled mode.
+        /// </summary>
+        /// <param name="name">Specifies the queue path.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public
+        async Task
+        SetQueueDisabled(
+            string name)
+        {
+            var queue = await this.serviceBusNamespaceManager.GetQueueAsync(name);
+
+            queue.Status = EntityStatus.Disabled;
+
+            await this.serviceBusNamespaceManager.UpdateQueueAsync(queue);
+        }
+
+        /// <summary>
+        /// Sets the specified Service Bus queue in to a Enabled mode for both reading and writing.
+        /// </summary>
+        /// <param name="name">Specifies the queue path.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public
+        async Task
+        SetQueueEnabled(
+            string name)
+        {
+            var queue = await this.serviceBusNamespaceManager.GetQueueAsync(name);
+
+            queue.Status = EntityStatus.Active;
+
+            await this.serviceBusNamespaceManager.UpdateQueueAsync(queue);
+        }
+
+        /// <summary>
         /// Creates the specified physical Service Bus queue using the specified description.
         /// </summary>
         /// <param name="queueDescription">Specifies the details of the queue to create.</param>

--- a/Source/ExampleApp.Web/Models/ServiceBusQueueServiceModel.cs
+++ b/Source/ExampleApp.Web/Models/ServiceBusQueueServiceModel.cs
@@ -88,6 +88,23 @@
         }
 
         /// <summary>
+        /// Sets the specified Service Bus queue in to a Receive-Only mode.
+        /// </summary>
+        /// <param name="name">Specifies the queue path.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public
+        async Task
+        SetQueueReceiveOnly(
+            string name)
+        {
+            var queue = await this.serviceBusNamespaceManager.GetQueueAsync(name);
+
+            queue.Status = EntityStatus.SendDisabled;
+
+            await this.serviceBusNamespaceManager.UpdateQueueAsync(queue);
+        }
+
+        /// <summary>
         /// Creates the specified physical Service Bus queue using the specified description.
         /// </summary>
         /// <param name="queueDescription">Specifies the details of the queue to create.</param>

--- a/Source/ExampleApp.Web/Models/ServiceBusQueueServiceModel.cs
+++ b/Source/ExampleApp.Web/Models/ServiceBusQueueServiceModel.cs
@@ -67,7 +67,7 @@
         ListQueues(
             string namePrefix)
         {
-            var getFilter = "startswith(path, '" + namePrefix + "-') eq true";
+            var getFilter = "startswith(path, '" + namePrefix + "') eq true";
 
             var queues = (await this.serviceBusNamespaceManager.GetQueuesAsync(getFilter)
                 .ConfigureAwait(false))

--- a/Source/Slinqy.Core.Test.Unit/SlinqyAgentTests.cs
+++ b/Source/Slinqy.Core.Test.Unit/SlinqyAgentTests.cs
@@ -259,7 +259,7 @@
         SlinqyQueueShard
         CreateFakeSendReceiveQueue()
         {
-            return this.CreateFakeShard(sendable: true, sendReceiveable: true);
+            return this.CreateFakeShard(sendable: true, receivable: true);
         }
 
         /// <summary>
@@ -272,7 +272,7 @@
         SlinqyQueueShard
         CreateFakeSendOnlyQueue()
         {
-            return this.CreateFakeShard(sendable: true, sendReceiveable: false);
+            return this.CreateFakeShard(sendable: true, receivable: false);
         }
 
         /// <summary>
@@ -285,21 +285,21 @@
         SlinqyQueueShard
         CreateFakeReceiveOnlyQueue()
         {
-            return this.CreateFakeShard(sendable: false, sendReceiveable: false);
+            return this.CreateFakeShard(sendable: false, receivable: false);
         }
 
         /// <summary>
         /// Creates a new fake SlinqyQueueShard.
         /// </summary>
         /// <param name="sendable">Specifies if the fake shard can be sent to.</param>
-        /// <param name="sendReceiveable">Specifies if the fake shard can be received from.</param>
+        /// <param name="receivable">Specifies if the fake shard can be received from.</param>
         /// <param name="maxSizeMegabytes">Specifies the max size of the fake shard.</param>
         /// <returns>Returns the fake shard.</returns>
         private
         SlinqyQueueShard
         CreateFakeShard(
             bool sendable           = true,
-            bool sendReceiveable    = true,
+            bool receivable         = true,
             long maxSizeMegabytes   = ValidMaxSizeMegabytes)
         {
             var fakeShard           = A.Fake<SlinqyQueueShard>();
@@ -308,7 +308,7 @@
             A.CallTo(() => fakeShard.ShardIndex                 ).Returns(this.shardIndexCounter++);
             A.CallTo(() => fakePhysicalQueue.Name               ).Returns(ValidSlinqyQueueName + fakeShard.ShardIndex);
             A.CallTo(() => fakePhysicalQueue.IsSendEnabled      ).Returns(sendable);
-            A.CallTo(() => fakePhysicalQueue.ReadWritable       ).Returns(sendReceiveable);
+            A.CallTo(() => fakePhysicalQueue.IsReceiveEnabled   ).Returns(receivable);
             A.CallTo(() => fakePhysicalQueue.MaxSizeMegabytes   ).Returns(maxSizeMegabytes);
 
             return fakeShard;

--- a/Source/Slinqy.Core.Test.Unit/SlinqyAgentTests.cs
+++ b/Source/Slinqy.Core.Test.Unit/SlinqyAgentTests.cs
@@ -2,11 +2,8 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Globalization;
-    using System.Linq;
     using System.Threading.Tasks;
     using FakeItEasy;
-    using FakeItEasy.Core;
     using Xunit;
 
     /// <summary>
@@ -19,12 +16,6 @@
         /// Should not be a special value other than it is guaranteed to be valid.
         /// </summary>
         private const string ValidSlinqyQueueName = "queue-name";
-
-        /// <summary>
-        /// Represents a valid value where one is needed for queue shard index parameters.
-        /// Should not be a special value other than it is guaranteed to be valid.
-        /// </summary>
-        private const int ValidShardIndex = 0;
 
         /// <summary>
         /// Represents a valid value where one is needed for max size parameters.
@@ -51,7 +42,7 @@
         /// <summary>
         /// A fake SlinqyQueueShard that is configured to be writable.
         /// </summary>
-        private readonly SlinqyQueueShard fakeSendableShard;
+        private readonly SlinqyQueueShard fakeShard;
 
         /// <summary>
         /// A fake SlinqyQueueShardMonitor.
@@ -75,11 +66,11 @@
         SlinqyAgentTests()
         {
             // Configures one read/writable shard since that's the minimum valid state.
-            this.fakeSendableShard = this.CreateFakeSendReceiveQueue();
+            this.fakeShard = this.CreateFakeSendReceiveQueue();
 
             // Configures the fake shard monitor to use the fake shards.
             this.fakeQueueShardMonitor = A.Fake<SlinqyQueueShardMonitor>();
-            this.fakeShards = new List<SlinqyQueueShard> { this.fakeSendableShard };
+            this.fakeShards = new List<SlinqyQueueShard> { this.fakeShard };
 
             A.CallTo(() => this.fakeQueueShardMonitor.QueueName).Returns(ValidSlinqyQueueName);
             A.CallTo(() => this.fakeQueueShardMonitor.Shards).Returns(this.fakeShards);
@@ -106,7 +97,7 @@
             var scaleOutSizeMegabytes = Math.Ceiling(ValidMaxSizeMegabytes * ValidStorageCapacityScaleOutThreshold);
             var scaleOutSizeBytes     = Convert.ToInt64(scaleOutSizeMegabytes * 1024 * 1024);
 
-            A.CallTo(() => this.fakeSendableShard.PhysicalQueue.CurrentSizeBytes).Returns(scaleOutSizeBytes);
+            A.CallTo(() => this.fakeShard.PhysicalQueue.CurrentSizeBytes).Returns(scaleOutSizeBytes);
 
             // Act
             await this.slinqyAgent.Start();
@@ -131,7 +122,7 @@
             var scaleOutSizeMegabytes = Math.Floor(ValidMaxSizeMegabytes * ValidStorageCapacityScaleOutThreshold);
             var sizeBytes             = Convert.ToInt64(scaleOutSizeMegabytes * 1024 * 1024);
 
-            A.CallTo(() => this.fakeSendableShard.PhysicalQueue.CurrentSizeBytes).Returns(sizeBytes);
+            A.CallTo(() => this.fakeShard.PhysicalQueue.CurrentSizeBytes).Returns(sizeBytes);
 
             // Act
             await this.slinqyAgent.Start();
@@ -155,7 +146,7 @@
             var scaleOutSizeMegabytes   = Math.Ceiling(ValidMaxSizeMegabytes * ValidStorageCapacityScaleOutThreshold);
             var scaleOutSizeBytes       = Convert.ToInt64(scaleOutSizeMegabytes * 1024 * 1024);
 
-            A.CallTo(() => this.fakeSendableShard.PhysicalQueue.CurrentSizeBytes).Returns(scaleOutSizeBytes);
+            A.CallTo(() => this.fakeShard.PhysicalQueue.CurrentSizeBytes).Returns(scaleOutSizeBytes);
 
             // Act
             await this.slinqyAgent.Start();
@@ -180,7 +171,7 @@
             var scaleOutSizeBytes     = Convert.ToInt64(scaleOutSizeMegabytes * 1024 * 1024);
 
             // Configure the write shards size to trigger scaling.
-            A.CallTo(() => this.fakeSendableShard.PhysicalQueue.CurrentSizeBytes).Returns(scaleOutSizeBytes);
+            A.CallTo(() => this.fakeShard.PhysicalQueue.CurrentSizeBytes).Returns(scaleOutSizeBytes);
 
             // Configure the new shard that will be added as a result of the scaling.
             var fakeAdditionalShard = this.CreateFakeSendOnlyQueue();
@@ -194,7 +185,7 @@
 
             // Assert
             A.CallTo(() =>
-                this.fakeQueueService.SetQueueReceiveOnly(this.fakeSendableShard.PhysicalQueue.Name)
+                this.fakeQueueService.SetQueueReceiveOnly(this.fakeShard.PhysicalQueue.Name)
             ).MustHaveHappened();
         }
 
@@ -211,43 +202,27 @@
             var scaleOutSizeMegabytes = Math.Ceiling(ValidMaxSizeMegabytes * ValidStorageCapacityScaleOutThreshold);
             var scaleOutSizeBytes     = Convert.ToInt64(scaleOutSizeMegabytes * 1024 * 1024);
 
-            var fakeSendableQueue = A.Fake<SlinqyQueueShard>();
+            // Configure the initial default shard to be receive-only.
+            A.CallTo(() => this.fakeShard.PhysicalQueue.IsSendEnabled).Returns(false);
 
-            A.CallTo(() => fakeSendableQueue.ShardIndex).Returns(0);
-            A.CallTo(() => fakeSendableQueue.PhysicalQueue.Name).Returns(ValidSlinqyQueueName + 0);
-            A.CallTo(() => fakeSendableQueue.PhysicalQueue.IsSendEnabled).Returns(false);
-            A.CallTo(() => fakeSendableQueue.PhysicalQueue.CurrentSizeBytes).Returns(1);
+            // Create a new send-only shard that has exceeded the scale out threshold,
+            // this will become the middle shard after scaling occurs.
+            var sendOnlyShard = this.CreateFakeSendOnlyQueue(currentSizeBytes: scaleOutSizeBytes);
+            this.fakeShards.Add(sendOnlyShard);
 
-            A.CallTo(() => this.fakeSendableShard.ShardIndex).Returns(1);
-            A.CallTo(() => this.fakeSendableShard.PhysicalQueue.IsSendEnabled).Returns(true);
+            // Configure the new shard that will be added as a result of the scaling.
+            var newSendOnlyShard = this.CreateFakeSendOnlyQueue();
 
-            var shards = new List<SlinqyQueueShard> {
-                fakeSendableQueue,
-                this.fakeSendableShard
-            };
-
-            A.CallTo(() => this.fakeSendableShard.PhysicalQueue.CurrentSizeBytes).Returns(scaleOutSizeBytes);
-            A.CallTo(() => this.fakeQueueShardMonitor.Shards).Returns(shards);
-
-            var newWritableShard = A.Fake<IPhysicalQueue>();
-
-            A.CallTo(() => newWritableShard.Name).Returns(ValidSlinqyQueueName + (this.fakeSendableShard.ShardIndex + 1));
-            A.CallTo(() => newWritableShard.IsSendEnabled).Returns(true);
-
-            var newShards = new List<IPhysicalQueue> {
-                fakeSendableQueue.PhysicalQueue,
-                this.fakeSendableShard.PhysicalQueue,
-                newWritableShard
-            };
-
-            A.CallTo(() => this.fakeQueueService.ListQueues(ValidSlinqyQueueName)).Returns(newShards);
+            A.CallTo(() => this.fakeQueueService.CreateSendOnlyQueue(A<string>.Ignored))
+                .Invokes(() => this.fakeShards.Add(newSendOnlyShard))
+                .Returns(newSendOnlyShard.PhysicalQueue);
 
             // Act
             await this.slinqyAgent.Start();
 
             // Assert
             A.CallTo(() =>
-                this.fakeQueueService.SetQueueDisabled(this.fakeSendableShard.PhysicalQueue.Name)
+                this.fakeQueueService.SetQueueDisabled(this.fakeShard.PhysicalQueue.Name)
             ).MustHaveHappened();
         }
 
@@ -265,14 +240,20 @@
         /// <summary>
         /// Creates a new instance of SlinqyQueueShard as a fake that is configured to simulate a send-only queue.
         /// </summary>
+        /// <param name="currentSizeBytes">Specifies the current size of the fake shard.</param>
         /// <returns>
         /// Returns a fake that simulates a new queue shard.
         /// </returns>
         private
         SlinqyQueueShard
-        CreateFakeSendOnlyQueue()
+        CreateFakeSendOnlyQueue(
+            long currentSizeBytes = 0)
         {
-            return this.CreateFakeShard(sendable: true, receivable: false);
+            return this.CreateFakeShard(
+                sendable:           true,
+                receivable:         false,
+                currentSizeBytes:   currentSizeBytes
+            );
         }
 
         /// <summary>
@@ -294,13 +275,15 @@
         /// <param name="sendable">Specifies if the fake shard can be sent to.</param>
         /// <param name="receivable">Specifies if the fake shard can be received from.</param>
         /// <param name="maxSizeMegabytes">Specifies the max size of the fake shard.</param>
+        /// <param name="currentSizeBytes">Specifies the current size of the fake shard.</param>
         /// <returns>Returns the fake shard.</returns>
         private
         SlinqyQueueShard
         CreateFakeShard(
             bool sendable           = true,
             bool receivable         = true,
-            long maxSizeMegabytes   = ValidMaxSizeMegabytes)
+            long maxSizeMegabytes   = ValidMaxSizeMegabytes,
+            long currentSizeBytes   = 0)
         {
             var fakeShard           = A.Fake<SlinqyQueueShard>();
             var fakePhysicalQueue   = fakeShard.PhysicalQueue;
@@ -310,6 +293,7 @@
             A.CallTo(() => fakePhysicalQueue.IsSendEnabled      ).Returns(sendable);
             A.CallTo(() => fakePhysicalQueue.IsReceiveEnabled   ).Returns(receivable);
             A.CallTo(() => fakePhysicalQueue.MaxSizeMegabytes   ).Returns(maxSizeMegabytes);
+            A.CallTo(() => fakePhysicalQueue.CurrentSizeBytes   ).Returns(currentSizeBytes);
 
             return fakeShard;
         }

--- a/Source/Slinqy.Core.Test.Unit/SlinqyAgentTests.cs
+++ b/Source/Slinqy.Core.Test.Unit/SlinqyAgentTests.cs
@@ -93,7 +93,7 @@
         [Fact]
         public
         async Task
-        SlinqyAgent_WriteQueueShardExceedsCapacityThreshold_AnotherShardIsAdded()
+        SlinqyAgent_WriteQueueShardExceedsCapacityThreshold_ASendOnlyShardIsAdded()
         {
             // Arrange
             var scaleOutSizeMegabytes = Math.Ceiling(ValidMaxSizeMegabytes * ValidStorageCapacityScaleOutThreshold);
@@ -106,7 +106,7 @@
 
             // Assert
             A.CallTo(() =>
-                this.fakeQueueService.CreateQueue(A<string>.Ignored)
+                this.fakeQueueService.CreateSendOnlyQueue(A<string>.Ignored)
             ).MustHaveHappened();
         }
 
@@ -155,7 +155,7 @@
 
             // Assert
             A.CallTo(() =>
-                this.fakeQueueService.CreateQueue(ValidSlinqyQueueName + "1")
+                this.fakeQueueService.CreateSendOnlyQueue(ValidSlinqyQueueName + "1")
             ).MustHaveHappened();
         }
     }

--- a/Source/Slinqy.Core.Test.Unit/SlinqyAgentTests.cs
+++ b/Source/Slinqy.Core.Test.Unit/SlinqyAgentTests.cs
@@ -158,5 +158,29 @@
                 this.fakeQueueService.CreateSendOnlyQueue(ValidSlinqyQueueName + "1")
             ).MustHaveHappened();
         }
+
+        /// <summary>
+        /// Verifies that the previous shard is set to be receive only after a new write shard is added.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public
+        async Task
+        SlinqyAgent_AnotherShardAdded_PreviousShardIsReceiveOnly()
+        {
+            // Arrange
+            var scaleOutSizeMegabytes = Math.Ceiling(ValidMaxSizeMegabytes * ValidStorageCapacityScaleOutThreshold);
+            var scaleOutSizeBytes     = Convert.ToInt64(scaleOutSizeMegabytes * 1024 * 1024);
+
+            A.CallTo(() => this.fakeWritableShard.PhysicalQueue.CurrentSizeBytes).Returns(scaleOutSizeBytes);
+
+            // Act
+            await this.slinqyAgent.Start();
+
+            // Assert
+            A.CallTo(() =>
+                this.fakeQueueService.SetQueueReceiveOnly(this.fakeWritableShard.PhysicalQueue.Name)
+            ).MustHaveHappened();
+        }
     }
 }

--- a/Source/Slinqy.Core.Test.Unit/SlinqyQueueShardMonitorTests.cs
+++ b/Source/Slinqy.Core.Test.Unit/SlinqyQueueShardMonitorTests.cs
@@ -93,7 +93,7 @@
             ).Returns(ValidSlinqyQueueName + "0");
 
             A.CallTo(() =>
-                fakeReadWritePhysicalQueue.Writable
+                fakeReadWritePhysicalQueue.IsSendEnabled
             ).Returns(true);
 
             var physicalQueues = new List<IPhysicalQueue> {
@@ -110,7 +110,7 @@
             // Assert
             Assert.Equal(
                 fakeReadWritePhysicalQueue.Name,
-                this.monitor.WriteShard.PhysicalQueue.Name
+                this.monitor.SendShard.PhysicalQueue.Name
             );
         }
 
@@ -128,9 +128,9 @@
             var fakeWritePhysicalQueue = A.Fake<IPhysicalQueue>();
 
             A.CallTo(() => fakeReadPhysicalQueue.Name).Returns("shard0");
-            A.CallTo(() => fakeReadPhysicalQueue.Writable).Returns(false);
+            A.CallTo(() => fakeReadPhysicalQueue.IsSendEnabled).Returns(false);
             A.CallTo(() => fakeWritePhysicalQueue.Name).Returns("shard1");
-            A.CallTo(() => fakeWritePhysicalQueue.Writable).Returns(true);
+            A.CallTo(() => fakeWritePhysicalQueue.IsSendEnabled).Returns(true);
 
             var physicalQueues = new List<IPhysicalQueue> {
                 fakeReadPhysicalQueue,
@@ -147,7 +147,7 @@
             // Assert
             Assert.Equal(
                 fakeWritePhysicalQueue.Name,
-                this.monitor.WriteShard.PhysicalQueue.Name
+                this.monitor.SendShard.PhysicalQueue.Name
             );
         }
 
@@ -167,15 +167,15 @@
             var fakeDisabled3PhysicalQueue = A.Fake<IPhysicalQueue>();
             var fakeWritePhysicalQueue     = A.Fake<IPhysicalQueue>();
 
-            A.CallTo(() => fakeReadPhysicalQueue.Writable).Returns(false);
+            A.CallTo(() => fakeReadPhysicalQueue.IsSendEnabled).Returns(false);
             A.CallTo(() => fakeReadPhysicalQueue.Name).Returns("shard0");
-            A.CallTo(() => fakeDisabled1PhysicalQueue.Writable).Returns(false);
+            A.CallTo(() => fakeDisabled1PhysicalQueue.IsSendEnabled).Returns(false);
             A.CallTo(() => fakeDisabled1PhysicalQueue.Name).Returns("shard1");
-            A.CallTo(() => fakeDisabled2PhysicalQueue.Writable).Returns(false);
+            A.CallTo(() => fakeDisabled2PhysicalQueue.IsSendEnabled).Returns(false);
             A.CallTo(() => fakeDisabled2PhysicalQueue.Name).Returns("shard2");
-            A.CallTo(() => fakeDisabled3PhysicalQueue.Writable).Returns(false);
+            A.CallTo(() => fakeDisabled3PhysicalQueue.IsSendEnabled).Returns(false);
             A.CallTo(() => fakeDisabled3PhysicalQueue.Name).Returns("shard3");
-            A.CallTo(() => fakeWritePhysicalQueue.Writable).Returns(true);
+            A.CallTo(() => fakeWritePhysicalQueue.IsSendEnabled).Returns(true);
             A.CallTo(() => fakeWritePhysicalQueue.Name).Returns("shard4");
 
             var physicalQueues = new List<IPhysicalQueue> {
@@ -193,7 +193,7 @@
             // Assert
             Assert.Equal(
                 fakeWritePhysicalQueue.Name,
-                this.monitor.WriteShard.PhysicalQueue.Name
+                this.monitor.SendShard.PhysicalQueue.Name
             );
         }
 
@@ -217,11 +217,11 @@
             var fakeOldWritePhysicalQueue = A.Fake<IPhysicalQueue>();
             var fakeNewWritePhysicalQueue = A.Fake<IPhysicalQueue>();
 
-            A.CallTo(() => fakeReadPhysicalQueue.Writable).Returns(false);
+            A.CallTo(() => fakeReadPhysicalQueue.IsSendEnabled).Returns(false);
             A.CallTo(() => fakeReadPhysicalQueue.Name).Returns("shard0");
-            A.CallTo(() => fakeOldWritePhysicalQueue.Writable).Returns(true);
+            A.CallTo(() => fakeOldWritePhysicalQueue.IsSendEnabled).Returns(true);
             A.CallTo(() => fakeOldWritePhysicalQueue.Name).Returns("shard1");
-            A.CallTo(() => fakeNewWritePhysicalQueue.Writable).Returns(true);
+            A.CallTo(() => fakeNewWritePhysicalQueue.IsSendEnabled).Returns(true);
             A.CallTo(() => fakeNewWritePhysicalQueue.Name).Returns("shard2");
 
             var physicalQueues = new List<IPhysicalQueue> {
@@ -240,7 +240,7 @@
             // Assert
             Assert.Equal(
                 fakeNewWritePhysicalQueue.Name,
-                this.monitor.WriteShard.PhysicalQueue.Name
+                this.monitor.SendShard.PhysicalQueue.Name
             );
         }
     }

--- a/Source/Slinqy.Core.Test.Unit/SlinqyQueueShardMonitorTests.cs
+++ b/Source/Slinqy.Core.Test.Unit/SlinqyQueueShardMonitorTests.cs
@@ -127,9 +127,9 @@
             var fakeReadPhysicalQueue  = A.Fake<IPhysicalQueue>();
             var fakeWritePhysicalQueue = A.Fake<IPhysicalQueue>();
 
-            A.CallTo(() => fakeReadPhysicalQueue.Name).Returns("shard-0");
+            A.CallTo(() => fakeReadPhysicalQueue.Name).Returns("shard0");
             A.CallTo(() => fakeReadPhysicalQueue.Writable).Returns(false);
-            A.CallTo(() => fakeWritePhysicalQueue.Name).Returns("shard-1");
+            A.CallTo(() => fakeWritePhysicalQueue.Name).Returns("shard1");
             A.CallTo(() => fakeWritePhysicalQueue.Writable).Returns(true);
 
             var physicalQueues = new List<IPhysicalQueue> {
@@ -168,15 +168,15 @@
             var fakeWritePhysicalQueue     = A.Fake<IPhysicalQueue>();
 
             A.CallTo(() => fakeReadPhysicalQueue.Writable).Returns(false);
-            A.CallTo(() => fakeReadPhysicalQueue.Name).Returns("shard-0");
+            A.CallTo(() => fakeReadPhysicalQueue.Name).Returns("shard0");
             A.CallTo(() => fakeDisabled1PhysicalQueue.Writable).Returns(false);
-            A.CallTo(() => fakeDisabled1PhysicalQueue.Name).Returns("shard-1");
+            A.CallTo(() => fakeDisabled1PhysicalQueue.Name).Returns("shard1");
             A.CallTo(() => fakeDisabled2PhysicalQueue.Writable).Returns(false);
-            A.CallTo(() => fakeDisabled2PhysicalQueue.Name).Returns("shard-2");
+            A.CallTo(() => fakeDisabled2PhysicalQueue.Name).Returns("shard2");
             A.CallTo(() => fakeDisabled3PhysicalQueue.Writable).Returns(false);
-            A.CallTo(() => fakeDisabled3PhysicalQueue.Name).Returns("shard-3");
+            A.CallTo(() => fakeDisabled3PhysicalQueue.Name).Returns("shard3");
             A.CallTo(() => fakeWritePhysicalQueue.Writable).Returns(true);
-            A.CallTo(() => fakeWritePhysicalQueue.Name).Returns("shard-4");
+            A.CallTo(() => fakeWritePhysicalQueue.Name).Returns("shard4");
 
             var physicalQueues = new List<IPhysicalQueue> {
                 fakeReadPhysicalQueue,
@@ -218,11 +218,11 @@
             var fakeNewWritePhysicalQueue = A.Fake<IPhysicalQueue>();
 
             A.CallTo(() => fakeReadPhysicalQueue.Writable).Returns(false);
-            A.CallTo(() => fakeReadPhysicalQueue.Name).Returns("shard-0");
+            A.CallTo(() => fakeReadPhysicalQueue.Name).Returns("shard0");
             A.CallTo(() => fakeOldWritePhysicalQueue.Writable).Returns(true);
-            A.CallTo(() => fakeOldWritePhysicalQueue.Name).Returns("shard-1");
+            A.CallTo(() => fakeOldWritePhysicalQueue.Name).Returns("shard1");
             A.CallTo(() => fakeNewWritePhysicalQueue.Writable).Returns(true);
-            A.CallTo(() => fakeNewWritePhysicalQueue.Name).Returns("shard-2");
+            A.CallTo(() => fakeNewWritePhysicalQueue.Name).Returns("shard2");
 
             var physicalQueues = new List<IPhysicalQueue> {
                 fakeReadPhysicalQueue,

--- a/Source/Slinqy.Core.Test.Unit/SlinqyQueueShardTests.cs
+++ b/Source/Slinqy.Core.Test.Unit/SlinqyQueueShardTests.cs
@@ -15,7 +15,7 @@
         /// Represents a valid value where one is needed for a Slinqy shard name parameters.
         /// Should not be a special value other than it is guaranteed to be valid.
         /// </summary>
-        private const string ValidSlinqyShardName = "queue-name-0";
+        private const string ValidSlinqyShardName = "queue-name0";
 
         /// <summary>
         /// The fake that simulates a physical queue.
@@ -82,7 +82,7 @@
             // Arrange
             A.CallTo(() =>
                 this.fakePhysicalQueue.Name
-            ).Returns("queue-100");
+            ).Returns("queue100");
 
             // Act
             var actualShardIndex = this.slinqyQueueShard.ShardIndex;

--- a/Source/Slinqy.Core.Test.Unit/SlinqyQueueShardTests.cs
+++ b/Source/Slinqy.Core.Test.Unit/SlinqyQueueShardTests.cs
@@ -110,5 +110,25 @@
             // Assert
             Assert.Equal(0.5, actualPercentage);
         }
+
+        /// <summary>
+        /// Verifies that the IsDisabled property returns true when both sending
+        /// and receiving is disabled on the underlying physical queue.
+        /// </summary>
+        [Fact]
+        public
+        void
+        IsDisabled_SendDisabledReceiveDisabled_ReturnsTrue()
+        {
+            // Arrange
+            A.CallTo(() => this.fakePhysicalQueue.IsSendEnabled).Returns(false);
+            A.CallTo(() => this.fakePhysicalQueue.IsReceiveEnabled).Returns(false);
+
+            // Act
+            var actualValue = this.slinqyQueueShard.IsDisabled;
+
+            // Assert
+            Assert.True(actualValue);
+        }
     }
 }

--- a/Source/Slinqy.Core.Test.Unit/SlinqyQueueTests.cs
+++ b/Source/Slinqy.Core.Test.Unit/SlinqyQueueTests.cs
@@ -34,8 +34,8 @@
             this.fakeReadShard  = A.Fake<SlinqyQueueShard>();
             this.fakeWriteShard = A.Fake<SlinqyQueueShard>();
 
-            A.CallTo(() => this.fakeReadShard.PhysicalQueue.Writable).Returns(false);
-            A.CallTo(() => this.fakeWriteShard.PhysicalQueue.Writable).Returns(true);
+            A.CallTo(() => this.fakeReadShard.PhysicalQueue.IsSendEnabled).Returns(false);
+            A.CallTo(() => this.fakeWriteShard.PhysicalQueue.IsSendEnabled).Returns(true);
 
             var shards = new List<SlinqyQueueShard> {
                 this.fakeReadShard,

--- a/Source/Slinqy.Core/IPhysicalQueue.cs
+++ b/Source/Slinqy.Core/IPhysicalQueue.cs
@@ -28,14 +28,14 @@
         long CurrentSizeBytes { get; }
 
         /// <summary>
-        /// Gets a value indicating whether sending new messages to the queue is enabled (true), or not (false).
+        /// Gets a value indicating whether sending (enqueuing) new messages to the queue is currently enabled (true), or not (false).
         /// </summary>
         bool IsSendEnabled { get; }
 
         /// <summary>
-        /// Gets a value indicating whether the queue supports both reading and writing (true), or not (false).
+        /// Gets a value indicating whether receiving (dequeuing) messages from the queue is currently enabled (true), or not (false).
         /// </summary>
-        bool ReadWritable { get; } // TODO: Consider repurposing to Receivable
+        bool IsReceiveEnabled { get; }
 
         /// <summary>
         /// Gets a value indicating whether the queue is disabled for both reading and writing (true), or not (false).

--- a/Source/Slinqy.Core/IPhysicalQueue.cs
+++ b/Source/Slinqy.Core/IPhysicalQueue.cs
@@ -33,6 +33,16 @@
         bool Writable { get; }
 
         /// <summary>
+        /// Gets a value indicating whether the queue supports both reading and writing (true), or not (false).
+        /// </summary>
+        bool ReadWritable { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the queue is disabled for both reading and writing (true), or not (false).
+        /// </summary>
+        bool Disabled { get; }
+
+        /// <summary>
         /// Sends a batch of messages to the queue.
         /// </summary>
         /// <param name="batch">Specifies the batch to send.</param>

--- a/Source/Slinqy.Core/IPhysicalQueue.cs
+++ b/Source/Slinqy.Core/IPhysicalQueue.cs
@@ -28,9 +28,9 @@
         long CurrentSizeBytes { get; }
 
         /// <summary>
-        /// Gets a value indicating whether the queue is writable (true) or not (false).
+        /// Gets a value indicating whether sending new messages to the queue is enabled (true), or not (false).
         /// </summary>
-        bool Writable { get; }
+        bool IsSendEnabled { get; }
 
         /// <summary>
         /// Gets a value indicating whether the queue supports both reading and writing (true), or not (false).

--- a/Source/Slinqy.Core/IPhysicalQueue.cs
+++ b/Source/Slinqy.Core/IPhysicalQueue.cs
@@ -38,11 +38,6 @@
         bool IsReceiveEnabled { get; }
 
         /// <summary>
-        /// Gets a value indicating whether the queue is disabled for both reading and writing (true), or not (false).
-        /// </summary>
-        bool Disabled { get; }
-
-        /// <summary>
         /// Sends a batch of messages to the queue.
         /// </summary>
         /// <param name="batch">Specifies the batch to send.</param>

--- a/Source/Slinqy.Core/IPhysicalQueue.cs
+++ b/Source/Slinqy.Core/IPhysicalQueue.cs
@@ -35,7 +35,7 @@
         /// <summary>
         /// Gets a value indicating whether the queue supports both reading and writing (true), or not (false).
         /// </summary>
-        bool ReadWritable { get; }
+        bool ReadWritable { get; } // TODO: Consider repurposing to Receivable
 
         /// <summary>
         /// Gets a value indicating whether the queue is disabled for both reading and writing (true), or not (false).

--- a/Source/Slinqy.Core/IPhysicalQueueService.cs
+++ b/Source/Slinqy.Core/IPhysicalQueueService.cs
@@ -47,5 +47,19 @@
         /// <param name="name">Specifies the name of the queue to update.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task SetQueueReceiveOnly(string name);
+
+        /// <summary>
+        /// Modifies the status of the specified queue to where clients cannot send or receive from the queue.
+        /// </summary>
+        /// <param name="name">Specifies the name of the queue to update.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task SetQueueDisabled(string name);
+
+        /// <summary>
+        /// Modifies the status of the specified queue to where clients can both send or receive from the queue.
+        /// </summary>
+        /// <param name="name">Specifies the name of the queue to update.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task SetQueueEnabled(string name);
     }
 }

--- a/Source/Slinqy.Core/IPhysicalQueueService.cs
+++ b/Source/Slinqy.Core/IPhysicalQueueService.cs
@@ -12,13 +12,22 @@
     public interface IPhysicalQueueService
     {
         /// <summary>
-        /// Creates a physical queue in the service with the specified name.
+        /// Creates a physical queue in the service with the specified name
+        /// that is enabled for both sending and receiving of queue messages.
         /// </summary>
         /// <param name="name">
         /// Specifies the name of the queue to create.
         /// </param>
         /// <returns>Returns the queue that was created.</returns>
         Task<IPhysicalQueue> CreateQueue(string name);
+
+        /// <summary>
+        /// Creates a physical queue in the service with the specified name
+        /// that is only enabled for sending of queue messages to the queue.
+        /// </summary>
+        /// <param name="name">The name of the queue to create.</param>
+        /// <returns>Returns the queue that was created.</returns>
+        Task<IPhysicalQueue> CreateSendOnlyQueue(string name);
 
         /// <summary>
         /// Lists the physical queues whose names matches the specified prefix.

--- a/Source/Slinqy.Core/IPhysicalQueueService.cs
+++ b/Source/Slinqy.Core/IPhysicalQueueService.cs
@@ -40,5 +40,12 @@
         /// </returns>
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "This rule wasn't designed for async Tasks.")]
         Task<IEnumerable<IPhysicalQueue>> ListQueues(string namePrefix);
+
+        /// <summary>
+        /// Modifies the status of the specified queue to where clients can only receive from the queue, sending is disabled.
+        /// </summary>
+        /// <param name="name">Specifies the name of the queue to update.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task SetQueueReceiveOnly(string name);
     }
 }

--- a/Source/Slinqy.Core/SlinqyAgent.cs
+++ b/Source/Slinqy.Core/SlinqyAgent.cs
@@ -105,9 +105,6 @@
 
             await this.queueService.CreateSendOnlyQueue(nextShardName)
                 .ConfigureAwait(false);
-
-            // Proactively tell the monitor to refresh so it sees the new shard immediately.
-            await this.queueShardMonitor.Refresh();
         }
 
         /// <summary>
@@ -144,7 +141,7 @@
 
             // Make sure all shards in between are disabled.
             var inBetweenShards = queues.Where(s =>
-                s.PhysicalQueue != receivableQueue ||
+                s.PhysicalQueue != receivableQueue &&
                 s.PhysicalQueue != sendableQueue
             );
 

--- a/Source/Slinqy.Core/SlinqyAgent.cs
+++ b/Source/Slinqy.Core/SlinqyAgent.cs
@@ -99,7 +99,7 @@
             var nextShardIndex = currentWriteShard.ShardIndex + 1;
             var nextShardName = this.queueShardMonitor.QueueName + nextShardIndex;
 
-            await this.queueService.CreateQueue(nextShardName)
+            await this.queueService.CreateSendOnlyQueue(nextShardName)
                 .ConfigureAwait(false);
 
             // Set the previous write shards new state.

--- a/Source/Slinqy.Core/SlinqyAgent.cs
+++ b/Source/Slinqy.Core/SlinqyAgent.cs
@@ -97,7 +97,7 @@
         {
             // Add next shard!
             var nextShardIndex = currentWriteShard.ShardIndex + 1;
-            var nextShardName = currentWriteShard.PhysicalQueue.Name + nextShardIndex;
+            var nextShardName = this.queueShardMonitor.QueueName + nextShardIndex;
 
             await this.queueService.CreateQueue(nextShardName)
                 .ConfigureAwait(false);

--- a/Source/Slinqy.Core/SlinqyAgent.cs
+++ b/Source/Slinqy.Core/SlinqyAgent.cs
@@ -103,6 +103,7 @@
                 .ConfigureAwait(false);
 
             // Set the previous write shards new state.
+            await this.queueService.SetQueueReceiveOnly(currentWriteShard.PhysicalQueue.Name);
             await this.SetShardStates().ConfigureAwait(false);
         }
 

--- a/Source/Slinqy.Core/SlinqyQueue.cs
+++ b/Source/Slinqy.Core/SlinqyQueue.cs
@@ -55,7 +55,7 @@
         SendBatch(
             IEnumerable<object> batch)
         {
-            return this.queueShardMonitor.WriteShard.SendBatch(batch);
+            return this.queueShardMonitor.SendShard.SendBatch(batch);
         }
     }
 }

--- a/Source/Slinqy.Core/SlinqyQueueClient.cs
+++ b/Source/Slinqy.Core/SlinqyQueueClient.cs
@@ -12,6 +12,11 @@
     public class SlinqyQueueClient
     {
         /// <summary>
+        /// Defines the default value for a shard index on a new queue.
+        /// </summary>
+        private const int DefaultShardIndex = 0;
+
+        /// <summary>
         /// Maintains a list of references to SlinqyQueue's that have been instantiated since they are expensive to create.
         /// </summary>
         private readonly ConcurrentDictionary<string, SlinqyQueue> slinqyQueues = new ConcurrentDictionary<string, SlinqyQueue>();
@@ -56,9 +61,9 @@
 
             var queueShardName = string.Format(
                 CultureInfo.InvariantCulture,
-                "{0}-{1}",
+                "{0}{1}",
                 queueName,
-                0
+                DefaultShardIndex
             );
 
             // Call the function to create the first physical queue shard to establish the virtual queue.

--- a/Source/Slinqy.Core/SlinqyQueueShard.cs
+++ b/Source/Slinqy.Core/SlinqyQueueShard.cs
@@ -60,6 +60,11 @@
         public double StorageUtilization => (((double)this.PhysicalQueue.CurrentSizeBytes / 1024) / 1024) / this.PhysicalQueue.MaxSizeMegabytes;
 
         /// <summary>
+        /// Gets a value indicating whether both sending and receiving are disabled on this queue.
+        /// </summary>
+        public virtual bool IsDisabled => !this.PhysicalQueue.IsReceiveEnabled && !this.PhysicalQueue.IsSendEnabled;
+
+        /// <summary>
         /// Sends the batch of messages to the physical queue shard.
         /// </summary>
         /// <param name="batch">

--- a/Source/Slinqy.Core/SlinqyQueueShardMonitor.cs
+++ b/Source/Slinqy.Core/SlinqyQueueShardMonitor.cs
@@ -70,7 +70,7 @@
         /// Updates the instances Shards collection based on the latest data from the physical queue service.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public
+        private
         async Task
         Refresh()
         {

--- a/Source/Slinqy.Core/SlinqyQueueShardMonitor.cs
+++ b/Source/Slinqy.Core/SlinqyQueueShardMonitor.cs
@@ -46,9 +46,9 @@
         public virtual IEnumerable<SlinqyQueueShard> Shards { get; private set; }
 
         /// <summary>
-        /// Gets the current write shard.
+        /// Gets the current shard for sending new queue messages.
         /// </summary>
-        public SlinqyQueueShard WriteShard => this.Shards.Last(s => s.PhysicalQueue.Writable);
+        public SlinqyQueueShard SendShard => this.Shards.Last(s => s.PhysicalQueue.IsSendEnabled);
 
         /// <summary>
         /// Starts polling the physical resources to update the Shards property values.

--- a/Source/Slinqy.Core/SlinqyQueueShardMonitor.cs
+++ b/Source/Slinqy.Core/SlinqyQueueShardMonitor.cs
@@ -59,7 +59,7 @@
         Start()
         {
             // Perform a manual poll now to validate that it works before returning.
-            await this.UpdateShards().ConfigureAwait(false);
+            await this.Refresh().ConfigureAwait(false);
 
             // Start polling
             this.pollQueuesTask = this.PollQueues();
@@ -70,9 +70,9 @@
         /// Updates the instances Shards collection based on the latest data from the physical queue service.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        private
+        public
         async Task
-        UpdateShards()
+        Refresh()
         {
             var physicalShards = await this.queueService.ListQueues(this.QueueName)
                 .ConfigureAwait(false);
@@ -90,7 +90,7 @@
         {
             while (true)
             {
-                await this.UpdateShards().ConfigureAwait(false);
+                await this.Refresh().ConfigureAwait(false);
                 await Task.Delay(1000).ConfigureAwait(false);
             }
         }

--- a/Source/Slinqy.Core/SlinqyQueueShardMonitor.cs
+++ b/Source/Slinqy.Core/SlinqyQueueShardMonitor.cs
@@ -38,7 +38,7 @@
         /// <summary>
         /// Gets the name of the Slinqy Queue being monitored.
         /// </summary>
-        public string QueueName { get; }
+        public virtual string QueueName { get; }
 
         /// <summary>
         /// Gets a list of SlinqyQueueShards for each physical queue found.  This list refreshes periodically.


### PR DESCRIPTION
Modifies the SlinqyAgent and related code to control state for multiple shards.

There can be only one send shard and one receive shard.  All other shards must be disabled.