### PR TITLE
Now enforces 100% code coverage in the CI script

### DIFF
--- a/Source/Scripts/CI.Functions.ps1
+++ b/Source/Scripts/CI.Functions.ps1
@@ -68,7 +68,7 @@ function Run-Tests {
         $PackagesPath,
         $ArtifactsPath,
         $TestDlls,
-        [switch]$ReportCodeCoverage
+        $CodeCoveragePercentageRequired
     )
 
     $xUnitPath           = Join-Path $Env:ChocolateyInstall 'bin\xunit.console.exe'
@@ -80,7 +80,7 @@ function Run-Tests {
     exec { . $openCoverPath -target:$xUnitPath -targetargs:$TestDlls -returntargetcode -register:user -output:$openCoverOutputPath -filter:'+[Slinqy.Core]*' }
     Set-Location $currentDir
 
-    if ($ReportCodeCoverage) {
+    if ($CodeCoveragePercentageRequired) {
         $reportGeneratorPath       = Join-Path $PackagesPath 'ReportGenerator.2.3.5.0\tools\ReportGenerator.exe'
         $reportGeneratorOutputPath = Join-Path $ArtifactsPath 'CoverageReport'
 
@@ -89,5 +89,22 @@ function Run-Tests {
         $coverallsPath = Join-Path $PackagesPath 'coveralls.io.1.3.4\tools\coveralls.net.exe'
 
         exec { . $coverallsPath --opencover $openCoverOutputPath }
+
+        # Check the percentage:
+        $totalSequencePoints = (Select-Xml `
+            -Path  $openCoverOutputPath `
+            -XPath '//SequencePoint').Count
+
+        $visitedSequencePoints = (Select-Xml `
+            -Path  $openCoverOutputPath `
+            -XPath "//SequencePoint[@vc!='0']").Count
+
+        $coveragePercentage = ($visitedSequencePoints / $totalSequencePoints) * 100
+
+        Write-Host "$visitedSequencePoints out of $totalSequencePoints sequence points covered: $coveragePercentage %"
+
+        if ($coveragePercentage -lt $CodeCoveragePercentageRequired) {
+            throw "$coveragePercentage% is not sufficient, $CodeCoveragePercentageRequired% must be covered."
+        }
     }
 }

--- a/Source/Scripts/CI.Tasks.ps1
+++ b/Source/Scripts/CI.Tasks.ps1
@@ -90,7 +90,7 @@ Task Build -depends Clean -description "Compiles all source code." {
         -PackagesPath  $PackagesPath `
         -ArtifactsPath $ArtifactsPath `
         -TestDlls      $TestDlls `
-        -ReportCodeCoverage
+        -CodeCoveragePercentageRequired 100
 
     Write-Host "done!"
     Write-Host


### PR DESCRIPTION
No more PR fail surprises due to decreased coverage!  Now will know much sooner on the command line.

This resolves issue stealthlab/slinqy#3.