### PR TITLE
Support More Than 10 Shards

### DIFF
--- a/Source/ExampleApp.Web/Controllers/SlinqyQueueController.cs
+++ b/Source/ExampleApp.Web/Controllers/SlinqyQueueController.cs
@@ -87,7 +87,10 @@
             if (createQueueModel == null)
                 throw new ArgumentNullException(nameof(createQueueModel));
 
-            var queue = await SlinqyQueueClient.CreateQueueAsync(createQueueModel.QueueName);
+            var queue = await SlinqyQueueClient.CreateQueueAsync(
+                queueName:          createQueueModel.QueueName,
+                shardIndexPadding:  4
+            );
 
             var monitor = new SlinqyQueueShardMonitor(
                 createQueueModel.QueueName,

--- a/Source/Slinqy.Core.Test.Unit/SlinqyAgentTests.cs
+++ b/Source/Slinqy.Core.Test.Unit/SlinqyAgentTests.cs
@@ -130,26 +130,6 @@
         }
 
         /// <summary>
-        /// Verifies that the name of the new shard is correct.
-        /// </summary>
-        [Fact]
-        public
-        void
-        SlinqyAgent_AnotherShardAdded_ShardNameIsCorrect()
-        {
-            // Arrange
-            A.CallTo(() => this.fakeShard.StorageUtilization).Returns(ValidStorageCapacityScaleOutThreshold + 0.01);
-
-            // Act
-            this.slinqyAgent.Start();
-
-            // Assert
-            A.CallTo(() =>
-                this.fakeQueueService.CreateSendOnlyQueue(ValidSlinqyQueueName + "1")
-            ).MustHaveHappened();
-        }
-
-        /// <summary>
         /// Verifies that the previous shard is set to be receive only after a new write shard is added.
         /// </summary>
         [Fact]

--- a/Source/Slinqy.Core.Test.Unit/SlinqyQueueShardTests.cs
+++ b/Source/Slinqy.Core.Test.Unit/SlinqyQueueShardTests.cs
@@ -51,6 +51,45 @@
         }
 
         /// <summary>
+        /// Verifies that the GenerateFirstShardName returns the correct
+        /// shard name when index padding is specified.
+        /// </summary>
+        [Fact]
+        public
+        static
+        void
+        GenerateFirstShardName_MultipleShardIndexPaddingIsSpecified_ReturnsCorrectName()
+        {
+            // Arrange
+            const int ShardIndexPadding = 2;
+
+            // Act
+            var actual = SlinqyQueueShard.GenerateFirstShardName(ValidSlinqyQueueName, ShardIndexPadding);
+
+            // Assert
+            Assert.Equal(ValidSlinqyQueueName + "00", actual);
+        }
+
+        /// <summary>
+        /// Verifies that GenerateNextShardName properly handles zero padding in shard names from existing shard names.
+        /// </summary>
+        [Fact]
+        public
+        static
+        void
+        GenerateNextShardName_ZeroPaddedShardName_ReturnsIncrementedShardNameWithMatchingPadding()
+        {
+            // Arrange
+            const string ExistingShardName = ValidSlinqyQueueName + "0001";
+
+            // Act
+            var actual = SlinqyQueueShard.GenerateNextShardName(ExistingShardName);
+
+            // Assert
+            Assert.Equal(ValidSlinqyQueueName + "0002", actual);
+        }
+
+        /// <summary>
         /// Verifies that the constructor checks the physicalQueue parameter.
         /// </summary>
         [Fact]
@@ -320,25 +359,6 @@
 
             // Assert
             Assert.False(actualValue);
-        }
-
-        /// <summary>
-        /// Verifies that GenerateNextShardName properly handles zero padding in shard names from existing shard names.
-        /// </summary>
-        [Fact]
-        public
-        void
-        GenerateNextShardName_ZeroPaddedShardName_ReturnsIncrementedShardNameWithMatchingPadding()
-        {
-            // Arrange
-            this.ToString();
-            const string ExistingShardName = ValidSlinqyQueueName + "0001";
-
-            // Act
-            var actual = SlinqyQueueShard.GenerateNextShardName(ExistingShardName);
-
-            // Assert
-            Assert.Equal(ValidSlinqyQueueName + "0002", actual);
         }
     }
 }

--- a/Source/Slinqy.Core.Test.Unit/SlinqyQueueShardTests.cs
+++ b/Source/Slinqy.Core.Test.Unit/SlinqyQueueShardTests.cs
@@ -12,10 +12,16 @@
     public class SlinqyQueueShardTests
     {
         /// <summary>
+        /// Represents a valid value where one is needed for a Slinqy queue name parameters.
+        /// Should not be a special value other than it is guaranteed to be valid.
+        /// </summary>
+        private const string ValidSlinqyQueueName = "queue-name";
+
+        /// <summary>
         /// Represents a valid value where one is needed for a Slinqy shard name parameters.
         /// Should not be a special value other than it is guaranteed to be valid.
         /// </summary>
-        private const string ValidSlinqyShardName = "queue-name0";
+        private const string ValidSlinqyShardName = ValidSlinqyQueueName + "0";
 
         /// <summary>
         /// Represents a valid value where one is needed for max wait timespan parameters.
@@ -314,6 +320,25 @@
 
             // Assert
             Assert.False(actualValue);
+        }
+
+        /// <summary>
+        /// Verifies that GenerateNextShardName properly handles zero padding in shard names from existing shard names.
+        /// </summary>
+        [Fact]
+        public
+        void
+        GenerateNextShardName_ZeroPaddedShardName_ReturnsIncrementedShardNameWithMatchingPadding()
+        {
+            // Arrange
+            this.ToString();
+            const string ExistingShardName = ValidSlinqyQueueName + "0001";
+
+            // Act
+            var actual = SlinqyQueueShard.GenerateNextShardName(ExistingShardName);
+
+            // Assert
+            Assert.Equal(ValidSlinqyQueueName + "0002", actual);
         }
     }
 }

--- a/Source/Slinqy.Core/SlinqyAgent.cs
+++ b/Source/Slinqy.Core/SlinqyAgent.cs
@@ -114,8 +114,7 @@
             SlinqyQueueShard currentSendShard)
         {
             // Add next shard!
-            var nextShardIndex = currentSendShard.ShardIndex + 1;
-            var nextShardName  = this.queueShardMonitor.QueueName + nextShardIndex;
+            var nextShardName = SlinqyQueueShard.GenerateNextShardName(currentSendShard.PhysicalQueue.Name);
 
             await this.queueService.CreateSendOnlyQueue(nextShardName)
                 .ConfigureAwait(false);

--- a/Source/Slinqy.Core/SlinqyQueueClient.cs
+++ b/Source/Slinqy.Core/SlinqyQueueClient.cs
@@ -50,20 +50,25 @@
         /// <param name="queueName">
         /// Specifies the name of the queue.
         /// </param>
+        /// <param name="shardIndexPadding">
+        /// Specifies how many digits should be used for the index part of the queue shard name.
+        /// For example:
+        /// CreateQueueAsync("my-queue", 1) will generate the following: "my-queue0", "my-queue1", "my-queue2", etc.
+        /// CreateQueueAsync("my-queue", 2) will generate the following: "my-queue00", "my-queue01", "my-queue02", etc.
+        /// </param>
         /// <returns>Returns the resulting SlinqyQueue that was created.</returns>
         public
         async Task<SlinqyQueue>
         CreateQueueAsync(
-            string queueName)
+            string  queueName,
+            int     shardIndexPadding)
         {
             if (string.IsNullOrWhiteSpace(queueName))
                 throw new ArgumentNullException(nameof(queueName));
 
-            var queueShardName = string.Format(
-                CultureInfo.InvariantCulture,
-                "{0}{1}",
-                queueName,
-                DefaultShardIndex
+            var queueShardName = SlinqyQueueShard.GenerateFirstShardName(
+                slinqyQueueName:    queueName,
+                shardIndexPadding:  shardIndexPadding
             );
 
             // Call the function to create the first physical queue shard to establish the virtual queue.
@@ -86,6 +91,23 @@
             this.slinqyQueues.TryAdd(queueName, queue);
 
             return queue;
+        }
+
+        /// <summary>
+        /// Creates a new queue with a default shardIndexPadding of 1,
+        /// which allows for a maximum of 10 (0 - 9).
+        /// </summary>
+        /// <param name="queueName">
+        /// Specifies the name of the queue.
+        /// </param>
+        /// <returns>Returns the resulting SlinqyQueue that was created.</returns>
+        public
+        async Task<SlinqyQueue>
+        CreateQueueAsync(
+            string  queueName)
+        {
+            return await this.CreateQueueAsync(queueName, 1)
+                .ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Source/Slinqy.Core/SlinqyQueueShard.cs
+++ b/Source/Slinqy.Core/SlinqyQueueShard.cs
@@ -91,6 +91,28 @@
         public virtual bool IsSendReceiveEnabled => this.PhysicalQueue.IsReceiveEnabled && this.PhysicalQueue.IsSendEnabled;
 
         /// <summary>
+        /// Generates the name of the first physical queue shard for a Slinqy queue.
+        /// </summary>
+        /// <param name="slinqyQueueName">
+        /// Specifies the name of the Slinqy queue.
+        /// </param>
+        /// <param name="shardIndexPadding">
+        /// Specifies how many digits the shard index can occupy in the physical queue name.
+        /// </param>
+        /// <returns>
+        /// Returns the name of what the first physical queue shard should be.
+        /// </returns>
+        public
+        static
+        string
+        GenerateFirstShardName(
+            string  slinqyQueueName,
+            int     shardIndexPadding)
+        {
+            return slinqyQueueName + 0.ToString("D" + shardIndexPadding, CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
         /// Parses the specified shard name and generates the next one based on it.
         /// </summary>
         /// <param name="shardName">


### PR DESCRIPTION
Introduces a new parameter, shardIndexPadding, to the SlinqyQueueClient.CreateQueue method that allows the API user to specify how many places the index can occupy.  Unused places are padded with zeros.