### PR TITLE
Random Test Queue Names

### DIFF
--- a/Source/ExampleApp.Web/Controllers/SlinqyQueueController.cs
+++ b/Source/ExampleApp.Web/Controllers/SlinqyQueueController.cs
@@ -154,12 +154,12 @@
         /// <returns>Returns information about the fill status.</returns>
         [HttpGet]
         [Route("api/slinqy-queue/{queueName}/fill-request", Name = "GetFillQueueStatus")]
+        [SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "WebAPI will not route static methods.")]
         public
         FillQueueStatusViewModel
         GetFillQueueStatus(
             string queueName)
         {
-            this.ToString();
             return FillOperations[queueName];
         }
 
@@ -202,12 +202,12 @@
         /// <returns>Returns information about the receive status.</returns>
         [HttpGet]
         [Route("api/slinqy-queue/{queueName}/receive-request", Name = "GetReceiveQueueStatus")]
+        [SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "WebAPI will not route static methods.")]
         public
         ReceiveQueueStatusViewModel
         GetReceiveQueueStatus(
             string queueName)
         {
-            this.ToString();
             return ReceiveOperations[queueName];
         }
 

--- a/Source/Slinqy.Core/SlinqyQueueClient.cs
+++ b/Source/Slinqy.Core/SlinqyQueueClient.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Concurrent;
     using System.Diagnostics.CodeAnalysis;
-    using System.Globalization;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -11,11 +10,6 @@
     /// </summary>
     public class SlinqyQueueClient
     {
-        /// <summary>
-        /// Defines the default value for a shard index on a new queue.
-        /// </summary>
-        private const int DefaultShardIndex = 0;
-
         /// <summary>
         /// Maintains a list of references to SlinqyQueue's that have been instantiated since they are expensive to create.
         /// </summary>

--- a/Source/Slinqy.Test.Functional/Models/ExampleAppPages/CreateQueueForm.cs
+++ b/Source/Slinqy.Test.Functional/Models/ExampleAppPages/CreateQueueForm.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Globalization;
-    using System.Linq;
     using System.Threading;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Support.PageObjects;

--- a/Source/Slinqy.Test.Functional/Models/ExampleAppPages/CreateQueueForm.cs
+++ b/Source/Slinqy.Test.Functional/Models/ExampleAppPages/CreateQueueForm.cs
@@ -75,15 +75,11 @@
         ManageQueueSection
         CreateQueue()
         {
-            const int OneGb      = 1024;
-            const int OnePercent = 1;
-
-            var name = "test-" + StringUtilities.RandomString(4);
-
             var createParams = new CreateQueueParameters(
-                queueName:                  name,
-                storageCapacityMegabytes:   OneGb,
-                scaleUpThresholdPercentage: OnePercent
+                queueName:                  "test",
+                storageCapacityMegabytes:   1024,
+                scaleUpThresholdPercentage: 1,
+                randomizeQueueName:         true
             );
 
             return this.CreateQueue(createParams);
@@ -100,9 +96,14 @@
             if (createQueueParameters == null)
                 throw new ArgumentNullException(nameof(createQueueParameters));
 
+            var createQueueName = createQueueParameters.QueueName;
+
+            if (createQueueParameters.RandomizeQueueName)
+                createQueueName += StringUtilities.RandomString(4);
+
             // Enter parameters in to form.
             this.queueName.Clear();
-            this.queueName.SendKeys(createQueueParameters.QueueName);
+            this.queueName.SendKeys(createQueueName);
             this.maxQueueSizeMegabytes.Clear();
             this.maxQueueSizeMegabytes.SendKeys(createQueueParameters.StorageCapacityMegabytes.ToString(CultureInfo.InvariantCulture));
             this.storageCapacityScaleOutThresholdPercentage.Clear();

--- a/Source/Slinqy.Test.Functional/Models/ExampleAppPages/CreateQueueParameters.cs
+++ b/Source/Slinqy.Test.Functional/Models/ExampleAppPages/CreateQueueParameters.cs
@@ -11,15 +11,37 @@
         /// <param name="queueName">Specifies the name of the new queue.</param>
         /// <param name="storageCapacityMegabytes">Specifies the desired storage capacity for the new queue.</param>
         /// <param name="scaleUpThresholdPercentage">Specifies the scale up threshold for the new queue.</param>
+        /// <param name="randomizeQueueName">Specifies if random characters should be added to the queueName.</param>
+        public CreateQueueParameters(
+            string  queueName,
+            int     storageCapacityMegabytes,
+            int     scaleUpThresholdPercentage,
+            bool    randomizeQueueName)
+        {
+            this.QueueName                  = queueName;
+            this.RandomizeQueueName         = randomizeQueueName;
+            this.StorageCapacityMegabytes   = storageCapacityMegabytes;
+            this.ScaleUpThresholdPercentage = scaleUpThresholdPercentage;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CreateQueueParameters"/> class.
+        /// </summary>
+        /// <param name="queueName">Specifies the name of the new queue.</param>
+        /// <param name="storageCapacityMegabytes">Specifies the desired storage capacity for the new queue.</param>
+        /// <param name="scaleUpThresholdPercentage">Specifies the scale up threshold for the new queue.</param>
         public CreateQueueParameters(
             string  queueName,
             int     storageCapacityMegabytes,
             int     scaleUpThresholdPercentage)
+                : this(queueName, storageCapacityMegabytes, scaleUpThresholdPercentage, true)
         {
-            this.QueueName                  = queueName;
-            this.StorageCapacityMegabytes   = storageCapacityMegabytes;
-            this.ScaleUpThresholdPercentage = scaleUpThresholdPercentage;
         }
+
+        /// <summary>
+        /// Gets a value indicating whether random characters will be appended (true) to the QueueName, or not (false).
+        /// </summary>
+        public bool     RandomizeQueueName          { get; private set; }
 
         /// <summary>
         /// Gets the name of the new queue.

--- a/Source/Slinqy.Test.Functional/Steps/QueueSteps.cs
+++ b/Source/Slinqy.Test.Functional/Steps/QueueSteps.cs
@@ -65,6 +65,72 @@
         }
 
         /// <summary>
+        /// Verifies that all the queue messages can be received.
+        /// </summary>
+        [Then]
+        public
+        static
+        void
+        ThenTheAllTheMessagesCanBeReceived()
+        {
+            var sentCount = ContextGet<int>("sentCount");
+            var receivedCount = ContextGet<int>("receivedCount");
+
+            Assert.AreEqual(sentCount, receivedCount);
+        }
+
+        /// <summary>
+        /// Starts receiving messages from the queue.
+        /// </summary>
+        [When]
+        public
+        static
+        void
+        WhenTheQueueReceiverIsStarted()
+        {
+            var receivedCount = QueueSteps.ContextGet<ManageQueueSection>()
+                .QueueClient
+                .ReceiveQueue();
+
+            QueueSteps.ContextSet(receivedCount, nameof(receivedCount));
+        }
+
+        /// <summary>
+        /// Sends a randomly generated message to a previously created queue.
+        /// </summary>
+        [When]
+        public
+        static
+        void
+        WhenAMessageIsSent()
+        {
+            var sentMessage = QueueSteps.ContextGet<ManageQueueSection>()
+                .QueueClient
+                .SendMessage();
+
+            BaseSteps.ContextSet(sentMessage);
+        }
+
+        /// <summary>
+        /// Verifies that the message that was originally sent can be received.
+        /// </summary>
+        [Then]
+        public
+        static
+        void
+        ThenTheMessageCanBeReceived()
+        {
+            var sentMessage = ContextGet<string>();
+            var receivedMessage = ContextGet<ManageQueueSection>()
+                .QueueClient.ReceiveQueueMessage();
+
+            Assert.AreEqual(
+                sentMessage,
+                receivedMessage
+            );
+        }
+
+        /// <summary>
         /// Creates a Queue with the Queue Storage Utilization Scale Up Threshold setting.
         /// </summary>
         [Given]
@@ -126,39 +192,6 @@
         }
 
         /// <summary>
-        /// Starts receiving messages from the queue.
-        /// </summary>
-        [When]
-        public
-        void
-        WhenTheQueueReceiverIsStarted()
-        {
-            this.ToString();
-
-            var receivedCount = QueueSteps.ContextGet<ManageQueueSection>()
-                .QueueClient
-                .ReceiveQueue();
-
-            QueueSteps.ContextSet(receivedCount, nameof(receivedCount));
-        }
-
-        /// <summary>
-        /// Verifies that all the queue messages can be received.
-        /// </summary>
-        [Then]
-        public
-        void
-        ThenTheAllTheMessagesCanBeReceived()
-        {
-            this.ToString();
-
-            var sentCount     = ContextGet<int>("sentCount");
-            var receivedCount = ContextGet<int>("receivedCount");
-
-            Assert.AreEqual(sentCount, receivedCount);
-        }
-
-        /// <summary>
         /// Creates a minimal Slinqy Queue with all default settings.
         /// </summary>
         [Given]
@@ -173,43 +206,6 @@
                 .CreateQueue();
 
             QueueSteps.ContextSet(manageQueueSection);
-        }
-
-        /// <summary>
-        /// Sends a randomly generated message to a previously created queue.
-        /// </summary>
-        [When]
-        public
-        void
-        WhenAMessageIsSent()
-        {
-            this.ToString();
-
-            var sentMessage = QueueSteps.ContextGet<ManageQueueSection>()
-                .QueueClient
-                .SendMessage();
-
-            BaseSteps.ContextSet(sentMessage);
-        }
-
-        /// <summary>
-        /// Verifies that the message that was originally sent can be received.
-        /// </summary>
-        [Then]
-        public
-        void
-        ThenTheMessageCanBeReceived()
-        {
-            this.ToString();
-
-            var sentMessage     = ContextGet<string>();
-            var receivedMessage = ContextGet<ManageQueueSection>()
-                .QueueClient.ReceiveQueueMessage();
-
-            Assert.AreEqual(
-                sentMessage,
-                receivedMessage
-            );
         }
     }
 }


### PR DESCRIPTION
Modifies the functional integration tests to use more randomly generated queue names so that the tests can be run repeatedly without running in to conflicts with lefts overs from prior test runs without having to wait for a full environmental destroy/re-create process.