### PR TITLE
Expand Timeouts for Slower Environments

### DIFF
--- a/Source/Slinqy.Test.Functional/Models/ExampleAppPages/QueueClientSection.cs
+++ b/Source/Slinqy.Test.Functional/Models/ExampleAppPages/QueueClientSection.cs
@@ -116,7 +116,7 @@
                 from:           () => this.fillQueueButton.Enabled,
                 until:          enabled => enabled,
                 interval:       TimeSpan.FromMilliseconds(500),
-                maxDuration:    TimeSpan.FromSeconds(30)
+                maxDuration:    TimeSpan.FromSeconds(60)
             );
 
             // Get the # of messages from the UI.

--- a/Source/Slinqy.Test.Functional/Models/ExampleAppPages/QueueClientSection.cs
+++ b/Source/Slinqy.Test.Functional/Models/ExampleAppPages/QueueClientSection.cs
@@ -138,7 +138,7 @@
                 from:           () => this.receiveQueueButton.Enabled,
                 until:          enabled => enabled,
                 interval:       TimeSpan.FromMilliseconds(500),
-                maxDuration:    TimeSpan.FromSeconds(30)
+                maxDuration:    TimeSpan.FromSeconds(60)
             );
 
             // Get the # of messages from the UI.


### PR DESCRIPTION
Some environments are slower than others.  It appears some requests are timing out but actually succeeding seconds later.  So extending the timeouts to be a little more forgiving.