### PR TITLE
AJAX Status Widget

### DIFF
--- a/Source/ExampleApp.Web/App_Start/BundleConfig.cs
+++ b/Source/ExampleApp.Web/App_Start/BundleConfig.cs
@@ -33,6 +33,7 @@
             bundles.Add(new ScriptBundle("~/bundles/modernizr").Include("~/Scripts/modernizr-*"));
             bundles.Add(new ScriptBundle("~/bundles/bootstrap").Include("~/Scripts/bootstrap.js", "~/Scripts/respond.js"));
             bundles.Add(new StyleBundle("~/Content/css").Include("~/Content/bootstrap.css", "~/Content/site.css"));
+            bundles.Add(new ScriptBundle("~/bundles/slinqy").Include("~/Scripts/ajax.indicator.js"));
         }
     }
 }

--- a/Source/ExampleApp.Web/App_Start/BundleConfig.cs
+++ b/Source/ExampleApp.Web/App_Start/BundleConfig.cs
@@ -32,7 +32,7 @@
             bundles.Add(jqueryBundle);
             bundles.Add(new ScriptBundle("~/bundles/modernizr").Include("~/Scripts/modernizr-*"));
             bundles.Add(new ScriptBundle("~/bundles/bootstrap").Include("~/Scripts/bootstrap.js", "~/Scripts/respond.js"));
-            bundles.Add(new StyleBundle("~/Content/css").Include("~/Content/bootstrap.css", "~/Content/site.css"));
+            bundles.Add(new StyleBundle("~/Content/css").Include("~/Content/bootstrap.css", "~/Content/site.css", "~/Content/ajax-indicator.css"));
             bundles.Add(new ScriptBundle("~/bundles/slinqy").Include("~/Scripts/ajax.indicator.js"));
         }
     }

--- a/Source/ExampleApp.Web/Content/ajax-indicator.css
+++ b/Source/ExampleApp.Web/Content/ajax-indicator.css
@@ -1,0 +1,11 @@
+﻿.ajax-running {
+    color: darkorange;
+}
+
+.ajax-succeeded {
+    color: green;
+}
+
+.ajax-failed {
+    color: red;
+}

--- a/Source/ExampleApp.Web/ExampleApp.Web.csproj
+++ b/Source/ExampleApp.Web/ExampleApp.Web.csproj
@@ -48,6 +48,7 @@
     <Content Include="Content\bootstrap-theme.min.css" />
     <Content Include="Content\bootstrap.css" />
     <Content Include="Content\bootstrap.min.css" />
+    <Content Include="Content\ajax-indicator.css" />
     <Content Include="fonts\glyphicons-halflings-regular.svg" />
     <Content Include="Global.asax" />
     <Content Include="fonts\glyphicons-halflings-regular.woff2" />

--- a/Source/ExampleApp.Web/ExampleApp.Web.csproj
+++ b/Source/ExampleApp.Web/ExampleApp.Web.csproj
@@ -59,6 +59,7 @@
     <Content Include="Content\bootstrap-theme.min.css.map" />
     <Content Include="Content\bootstrap-theme.css.map" />
     <None Include="Scripts\jquery-2.1.4.intellisense.js" />
+    <Content Include="Scripts\ajax.indicator.js" />
     <Content Include="Scripts\bootstrap.js" />
     <Content Include="Scripts\bootstrap.min.js" />
     <Content Include="Scripts\jquery-2.1.4.js" />

--- a/Source/ExampleApp.Web/Scripts/ajax.indicator.js
+++ b/Source/ExampleApp.Web/Scripts/ajax.indicator.js
@@ -23,7 +23,7 @@ ajax = function () {
         }
     }
 
-    // Called when an aJAX request finished, regardless if it was successful or not.
+    // Called when an AJAX request finished, regardless if it was successful or not.
     function onAjaxRequestCompleted(statusElement) {
         statusElement
             .addClass('ajax-completed')

--- a/Source/ExampleApp.Web/Scripts/ajax.indicator.js
+++ b/Source/ExampleApp.Web/Scripts/ajax.indicator.js
@@ -1,0 +1,49 @@
+﻿// Adds an ajax namespace with functions for updating UI depending on AJAX operations.
+
+ajax = function () {
+    // Called when an AJAX request succeeds.
+    function onAjaxRequestSucceeded(statusElement) {
+        statusElement
+            .addClass('ajax-succeeded')
+            .text('$')
+            .attr('title', 'AJAX request succeeded!');
+    }
+
+    // Called when an AJAX request fails.
+    function onAjaxRequestFailed(request, type, message, statusElement) {
+        statusElement
+            .addClass('ajax-failed')
+            .text('Failed : ' + request.status + ' : ' + type + ' : ' + message + ' : ' + request.responseText);
+    }
+
+    // Called when an aJAX request finished, regardless if it was successful or not.
+    function onAjaxRequestCompleted(statusElement) {
+        statusElement
+            .addClass('ajax-completed')
+            .removeClass('ajax-running');
+    }
+
+    // Registers an AJAX request to be monitored and reported.
+    // ajaxRequest: A currently executing AJAX request.
+    // statusElement: a jQuery element that should be used to display the status of the AJAX request to the user.
+    function indicate(ajaxRequest, statusElement) {
+        // First update the status element to indicate to the user that the request is running.
+        statusElement
+            .text('>')
+            .attr('class', 'ajax-running') // reset the class attribute
+            .attr('title', 'Request submitting, awaiting a response from the server.');
+
+        // Register event handlers on the request.
+        ajaxRequest
+            .done(function()   { onAjaxRequestSucceeded(statusElement); })
+            .always(function() { onAjaxRequestCompleted(statusElement); })
+            .fail(function(request, type, message) {
+                 onAjaxRequestFailed(request, type, message, statusElement);
+            });
+    }
+
+    return {
+        // Define what gets exported in the parent namespace
+        indicate:indicate
+    }
+}();

--- a/Source/ExampleApp.Web/Scripts/ajax.indicator.js
+++ b/Source/ExampleApp.Web/Scripts/ajax.indicator.js
@@ -4,41 +4,50 @@ ajax = function () {
     // Called when an AJAX request succeeds.
     function onAjaxRequestSucceeded(statusElement) {
         statusElement
+            .addClass('glyphicon-ok-circle')
             .addClass('ajax-succeeded')
-            .text('$')
             .attr('title', 'AJAX request succeeded!');
     }
 
     // Called when an AJAX request fails.
-    function onAjaxRequestFailed(request, type, message, statusElement) {
+    function onAjaxRequestFailed(request, type, message, statusElement, autoShowError) {
+        var failedText = 'Failed : ' + request.status + ' : ' + type + ' : ' + message + ' : ' + request.responseText;
+
         statusElement
+            .addClass('glyphicon-remove-circle')
             .addClass('ajax-failed')
-            .text('Failed : ' + request.status + ' : ' + type + ' : ' + message + ' : ' + request.responseText);
+            .attr('title', failedText);
+
+        if (autoShowError) {
+            statusElement.text(failedText);
+        }
     }
 
     // Called when an aJAX request finished, regardless if it was successful or not.
     function onAjaxRequestCompleted(statusElement) {
         statusElement
             .addClass('ajax-completed')
-            .removeClass('ajax-running');
+            .removeClass('ajax-running')
+            .removeClass('glyphicon-circle-arrow-right');
     }
 
     // Registers an AJAX request to be monitored and reported.
-    // ajaxRequest: A currently executing AJAX request.
-    // statusElement: a jQuery element that should be used to display the status of the AJAX request to the user.
-    function indicate(ajaxRequest, statusElement) {
+    // ajaxRequest:   A currently executing AJAX request.
+    // statusElement: A jQuery element that should be used to display the status of the AJAX request to the user.
+    // autoShowError: A boolean value indicating whether error message content will be displayed (true) or require mouse-hover (false).
+    function indicate(ajaxRequest, statusElement, autoShowError) {
         // First update the status element to indicate to the user that the request is running.
         statusElement
-            .text('>')
-            .attr('class', 'ajax-running') // reset the class attribute
-            .attr('title', 'Request submitting, awaiting a response from the server.');
+            .attr('class', 'glyphicon glyphicon-circle-arrow-right ajax-running')
+            .attr('title', 'Request submitting, awaiting a response from the server.')
+            .text('');
 
         // Register event handlers on the request.
         ajaxRequest
             .done(function()   { onAjaxRequestSucceeded(statusElement); })
             .always(function() { onAjaxRequestCompleted(statusElement); })
             .fail(function(request, type, message) {
-                 onAjaxRequestFailed(request, type, message, statusElement);
+                onAjaxRequestFailed(request, type, message, statusElement, autoShowError);
             });
     }
 

--- a/Source/ExampleApp.Web/Views/Home/CreateQueue.cshtml
+++ b/Source/ExampleApp.Web/Views/Home/CreateQueue.cshtml
@@ -5,7 +5,7 @@
 <form id="CreateQueueForm">
     @Html.EditorForModel()
     <button id="CreateQueueButton" type="button">Create</button>
-    <div id="CreateQueueAjaxStatus">?</div>
+    <div id="CreateQueueAjaxStatus"></div>
 </form>
 
 <script type="text/javascript">
@@ -33,7 +33,7 @@
             .text('Creating');
 
         // The request should be starting or running at this point, start reporting status...
-        ajax.indicate(ajaxRequest, $('#CreateQueueAjaxStatus'));
+        ajax.indicate(ajaxRequest, $('#CreateQueueAjaxStatus'), true);
     }
 
     $(function () {

--- a/Source/ExampleApp.Web/Views/Home/CreateQueue.cshtml
+++ b/Source/ExampleApp.Web/Views/Home/CreateQueue.cshtml
@@ -4,45 +4,35 @@
 
 <form id="CreateQueueForm">
     @Html.EditorForModel()
-    <input id="CreateQueueButton" type="button" value="Create"/>
+    <button id="CreateQueueButton" type="button" onclick="CreateQueue()">Create</button>
+    <div id="CreateQueueAjaxStatus">?</div>
 </form>
 
 <script type="text/javascript">
-    // Called when the user initiates a create queue AJAX request.
-    function ReceiveMessageStarted() {
-        $('#AjaxStatus').text('STARTED');
-        $('#AjaxStatusMessage').text('Request submitting, awaiting a response from the server.');
-    }
-
-    function ReceiveMessageSucceeded(response) {
-        $('#AjaxResult').text('SUCCEEDED');
-        $('#AjaxStatusMessage').text('The last request was successful.');
-
+    function CreateQueueSucceeded(response) {
         var url = '@Url.Action("ManageQueue")?queueName=' + response.QueueName;
 
         // Swap out the Create Queue form for the Manage Queue form
         $('#MainBody').load(url);
     }
 
-    function ReceiveMessageFailed(response) {
-        $('#AjaxResult').text('FAILED');
-        $('#AjaxStatusMessage').text(response.responseText);
+    function CreateQueue() {
+        // Make the AJAX request and make sure the button works again afterward.
+        var ajaxRequest = $.post(
+            '@Url.HttpRouteUrl("CreateQueue", null)',
+            $('#CreateQueueForm').serialize()
+        ).always(function() {
+            $('#CreateQueueButton')
+                .prop('disabled', false)
+                .text('Create');
+        }).done(CreateQueueSucceeded);
+
+        // Disable the button so it cannot be clicked repeatedly.
+        $('#CreateQueueButton')
+            .prop('disabled', true)
+            .text('Creating');
+
+        // The request should be starting or running at this point, start reporting status...
+        ajax.indicate(ajaxRequest, $('#CreateQueueAjaxStatus'));
     }
-
-    function ReceiveMessageCompleted() {
-        $('#AjaxStatus').text('COMPLETED');
-    }
-
-    function ReceiveMessage() {
-        $.post('@Url.HttpRouteUrl("CreateQueue", null)', $('#CreateQueueForm').serialize())
-            .done(ReceiveMessageSucceeded)
-            .fail(ReceiveMessageFailed)
-            .always(ReceiveMessageCompleted);
-
-        ReceiveMessageStarted();
-    }
-
-    $(function () {
-        $('#CreateQueueButton').click(ReceiveMessage);
-    });
 </script>

--- a/Source/ExampleApp.Web/Views/Home/CreateQueue.cshtml
+++ b/Source/ExampleApp.Web/Views/Home/CreateQueue.cshtml
@@ -4,7 +4,7 @@
 
 <form id="CreateQueueForm">
     @Html.EditorForModel()
-    <button id="CreateQueueButton" type="button" onclick="CreateQueue()">Create</button>
+    <button id="CreateQueueButton" type="button">Create</button>
     <div id="CreateQueueAjaxStatus">?</div>
 </form>
 
@@ -35,4 +35,9 @@
         // The request should be starting or running at this point, start reporting status...
         ajax.indicate(ajaxRequest, $('#CreateQueueAjaxStatus'));
     }
+
+    $(function () {
+        // Tie the button to the function.
+        $('#CreateQueueButton').click(CreateQueue);
+    });
 </script>

--- a/Source/ExampleApp.Web/Views/Home/FillQueue.cshtml
+++ b/Source/ExampleApp.Web/Views/Home/FillQueue.cshtml
@@ -1,5 +1,7 @@
 ﻿@model ExampleApp.Web.Models.FillQueueCommandModel
 
+<h2>Fill the Queue with Random Data</h2>
+
 <form id="FillQueueForm">
     @Html.EditorForModel()
     <button id="StartFillingQueueButton" type="button">Start</button>
@@ -18,7 +20,7 @@
         // Disable the button so it cannot be double clicked, or more.
         $('#StartFillingQueueButton').prop('disabled', true);
 
-        ajax.indicate(ajaxRequest, $('#FillQueueStatusAjaxStatus'));
+        ajax.indicate(ajaxRequest, $('#FillQueueStatusAjaxStatus'), true);
     }
 
     function StartFillQueueSucceeded() {

--- a/Source/ExampleApp.Web/Views/Home/FillQueue.cshtml
+++ b/Source/ExampleApp.Web/Views/Home/FillQueue.cshtml
@@ -4,60 +4,35 @@
     @Html.EditorForModel()
     <button id="StartFillingQueueButton" type="button">Start</button>
     <span id="FillQueueMessagesSent">0</span> messages sent
+    <div id="FillQueueStatusAjaxStatus"></div>
 </form>
 
 <script type="text/javascript">
     function FillQueue() {
         var fillQueueUrl = '@Url.HttpRouteUrl("FillQueue", new { queueName = ViewBag.QueueName })';
         var payload = $('#FillQueueForm').serialize();
-        $.post(fillQueueUrl, payload)
-            .done(StartFillQueueSucceeded)
-            .fail(StartFillQueueFailed)
-            .always(StartFillQueueCompleted);
 
-        StartFillQueueStarted();
-    }
+        var ajaxRequest = $.post(fillQueueUrl, payload)
+            .done(StartFillQueueSucceeded);
 
-    // Called when the user initiates a fill queue AJAX request.
-    function StartFillQueueStarted() {
         // Disable the button so it cannot be double clicked, or more.
         $('#StartFillingQueueButton').prop('disabled', true);
 
-        $('#AjaxStatus').text('STARTED');
-        $('#AjaxStatusMessage').text('Request submitted, awaiting a response from the server.');
+        ajax.indicate(ajaxRequest, $('#FillQueueStatusAjaxStatus'));
     }
 
     function StartFillQueueSucceeded() {
-        $('#AjaxResult').text('SUCCEEDED');
-        $('#AjaxStatusMessage').text('Request accepted by server, the queue is now being filled...');
-
         // Start polling for completion...
         setTimeout(PollFillStatus, 500);
-    }
-
-    function StartFillQueueFailed(response) {
-        $('#AjaxResult').text('FAILED');
-        $('#AjaxStatusMessage').text(response.responseText);
-    }
-
-    function StartFillQueueCompleted() {
-        $('#AjaxStatus').text('COMPLETED');
     }
 
     function PollFillStatus() {
         var fillStatusUrl = '@Url.HttpRouteUrl("GetFillQueueStatus", new { queueName = ViewBag.QueueName })';
 
-        $.getJSON(fillStatusUrl)
-            .done(UpdateFillStatus)
-            .fail(UpdateFillStatusFailed)
-            .always(UpdateFillStatusCompleted);
+        var ajaxRequest = $.getJSON(fillStatusUrl)
+            .done(UpdateFillStatus);
 
-        GetFillQueueStatusStarted();
-    }
-
-    function GetFillQueueStatusStarted() {
-        $('#AjaxStatus').text('STARTED');
-        $('#AjaxStatusMessage').text('Request submitted, awaiting a response from the server.');
+        ajax.indicate(ajaxRequest, $('#FillQueueStatusAjaxStatus'));
     }
 
     function UpdateFillStatus(fillOperation) {
@@ -86,17 +61,6 @@
 
         $('#FillQueueMessagesSent')
             .text(fillOperation.SentCount);
-    }
-
-    function UpdateFillStatusFailed(response) {
-        $('#AjaxResult').text('FAILED');
-        $('#AjaxStatusMessage').text(response.responseText);
-
-        alert(response.responseText);
-    }
-
-    function UpdateFillStatusCompleted() {
-        $('#AjaxStatus').text('COMPLETED');
     }
 
     $(function () {

--- a/Source/ExampleApp.Web/Views/Home/Index.cshtml
+++ b/Source/ExampleApp.Web/Views/Home/Index.cshtml
@@ -5,7 +5,3 @@
 <div id="MainBody">
     @{ Html.RenderPartial("CreateQueue"); }
 </div>
-
-<hr/>
-
-<div id="AjaxStatus"></div><div id="AjaxResult"></div><div id="AjaxStatusMessage"></div>

--- a/Source/ExampleApp.Web/Views/Home/QueueInformation.cshtml
+++ b/Source/ExampleApp.Web/Views/Home/QueueInformation.cshtml
@@ -6,7 +6,7 @@
     @Html.LabelFor(m => m.CurrentQueueSizeMegabytes)    <span id="QueueInformation_CurrentQueueSize">@Model.CurrentQueueSizeMegabytes</span> MB
     @Html.LabelFor(m => m.MaxQueueSizeMegabytes)        <span id="QueueInformation_MaxQueueSize">@Model.MaxQueueSizeMegabytes</span> MB
 
-    <div id="QueueInformationAjaxStatus">?</div>
+    <div id="QueueInformationAjaxStatus"></div>
 
     <script type="text/javascript">
         function updateQueueInformation() {
@@ -20,7 +20,7 @@
                     setTimeout(updateQueueInformation, 2000);
                 });
 
-            ajax.indicate(ajaxRequest, $('#QueueInformationAjaxStatus'));
+            ajax.indicate(ajaxRequest, $('#QueueInformationAjaxStatus'), false);
         }
 
         updateQueueInformation();

--- a/Source/ExampleApp.Web/Views/Home/QueueInformation.cshtml
+++ b/Source/ExampleApp.Web/Views/Home/QueueInformation.cshtml
@@ -6,33 +6,21 @@
     @Html.LabelFor(m => m.CurrentQueueSizeMegabytes)    <span id="QueueInformation_CurrentQueueSize">@Model.CurrentQueueSizeMegabytes</span> MB
     @Html.LabelFor(m => m.MaxQueueSizeMegabytes)        <span id="QueueInformation_MaxQueueSize">@Model.MaxQueueSizeMegabytes</span> MB
 
+    <div id="QueueInformationAjaxStatus">?</div>
+
     <script type="text/javascript">
-        // TODO: Refactor in to a reusable AJAX UI status widget.
-
         function updateQueueInformation() {
-            $('#AjaxResult').text('');
-            $('#AjaxStatusMessage').text('');
-            $('#AjaxStatus').text('STARTING');
-
-            $.get('@Url.HttpRouteUrl("GetQueue", new {queueName = Model.QueueName})')
+            var ajaxRequest = $.get('@Url.HttpRouteUrl("GetQueue", new {queueName = Model.QueueName})')
                 .done(function (data) {
                     $('#QueueInformation_QueueName').text(data.QueueName);
                     $('#QueueInformation_CurrentQueueSize').text(data.CurrentQueueSizeMegabytes);
                     $('#QueueInformation_MaxQueueSize').text(data.MaxQueueSizeMegabytes);
-
-                    $('#AjaxResult').text('SUCCEEDED');
-                })
-                .fail(function (jqxhr, textStatus, error) {
-                    $('#AjaxResult').text('FAILED!');
-                    $('#AjaxStatusMessage').text('textStatus: ' + textStatus + 'error: ' + error + ', response: ' + JSON.stringify(jqxhr));
                 })
                 .always(function () {
-                    $('#AjaxStatus').text('COMPLETED');
-
                     setTimeout(updateQueueInformation, 2000);
                 });
 
-            $('#AjaxStatus').text('STARTED');
+            ajax.indicate(ajaxRequest, $('#QueueInformationAjaxStatus'));
         }
 
         updateQueueInformation();

--- a/Source/ExampleApp.Web/Views/Home/ReceiveMessage.cshtml
+++ b/Source/ExampleApp.Web/Views/Home/ReceiveMessage.cshtml
@@ -1,4 +1,6 @@
-﻿<div id="ReceiveMessageSection">
+﻿<h2>Dequeue a Message</h2>
+
+<div id="ReceiveMessageSection">
     <button id="ReceiveMessageButton" type="button">Receive</button>
     <div id="ReceivedMessageBody"></div>
     <div id="ReceiveMessageAjaxStatus"></div>
@@ -29,7 +31,7 @@
             .done(ReceiveMessageSucceeded)
             .always(ReceiveMessageCompleted);
 
-        ajax.indicate(ajaxRequest, $('#ReceiveMessageAjaxStatus'));
+        ajax.indicate(ajaxRequest, $('#ReceiveMessageAjaxStatus'), true);
 
         ReceiveMessageStarted();
     }

--- a/Source/ExampleApp.Web/Views/Home/ReceiveMessage.cshtml
+++ b/Source/ExampleApp.Web/Views/Home/ReceiveMessage.cshtml
@@ -1,7 +1,7 @@
 ﻿<div id="ReceiveMessageSection">
     <button id="ReceiveMessageButton" type="button">Receive</button>
     <div id="ReceivedMessageBody"></div>
-    <div id="ReceiveMessageAjaxStatus">?</div>
+    <div id="ReceiveMessageAjaxStatus"></div>
 </div>
 
 <script type="text/javascript">

--- a/Source/ExampleApp.Web/Views/Home/ReceiveMessage.cshtml
+++ b/Source/ExampleApp.Web/Views/Home/ReceiveMessage.cshtml
@@ -1,6 +1,7 @@
 ﻿<div id="ReceiveMessageSection">
     <button id="ReceiveMessageButton" type="button">Receive</button>
     <div id="ReceivedMessageBody"></div>
+    <div id="ReceiveMessageAjaxStatus">?</div>
 </div>
 
 <script type="text/javascript">
@@ -10,37 +11,25 @@
         $('#ReceiveMessageButton')
             .prop('disabled', true)
             .text('Receiving...');
-
-        $('#AjaxStatus').text('STARTED');
-        $('#AjaxStatusMessage').text('Request submitting, awaiting a response from the server.');
     }
 
     function ReceiveMessageSucceeded(messageBody) {
         $('#ReceivedMessageBody')
             .text(messageBody);
-
-        $('#AjaxResult').text('SUCCEEDED');
-        $('#AjaxStatusMessage').text('The last request was successful.');
-    }
-
-    function ReceiveMessageFailed(response) {
-        $('#AjaxResult').text('FAILED');
-        $('#AjaxStatusMessage').text(response.responseText);
     }
 
     function ReceiveMessageCompleted() {
         $('#ReceiveMessageButton')
             .prop('disabled', false)
             .text('Receive');
-
-        $('#AjaxStatus').text('COMPLETED');
     }
 
     function ReceiveMessage() {
-        $.get('@Url.HttpRouteUrl("ReceiveMessage", new { queueName = ViewBag.QueueName })')
+        var ajaxRequest = $.get('@Url.HttpRouteUrl("ReceiveMessage", new { queueName = ViewBag.QueueName })')
             .done(ReceiveMessageSucceeded)
-            .fail(ReceiveMessageFailed)
             .always(ReceiveMessageCompleted);
+
+        ajax.indicate(ajaxRequest, $('#ReceiveMessageAjaxStatus'));
 
         ReceiveMessageStarted();
     }

--- a/Source/ExampleApp.Web/Views/Home/ReceiveQueue.cshtml
+++ b/Source/ExampleApp.Web/Views/Home/ReceiveQueue.cshtml
@@ -4,7 +4,7 @@
     @Html.EditorForModel()
     <button id="StartReceivingQueueButton" type="button">Start</button>
     <div id="ReceiveQueueMessagesReceived">0</div> received
-    <div id="ReceiveQueueAjaxStatus">?</div>
+    <div id="ReceiveQueueAjaxStatus"></div>
 </form>
 
 <script type="text/javascript">

--- a/Source/ExampleApp.Web/Views/Home/ReceiveQueue.cshtml
+++ b/Source/ExampleApp.Web/Views/Home/ReceiveQueue.cshtml
@@ -4,16 +4,17 @@
     @Html.EditorForModel()
     <button id="StartReceivingQueueButton" type="button">Start</button>
     <div id="ReceiveQueueMessagesReceived">0</div> received
+    <div id="ReceiveQueueAjaxStatus">?</div>
 </form>
 
 <script type="text/javascript">
     function ReceiveQueue() {
         var receiveQueueUrl = '@Url.HttpRouteUrl("ReceiveQueue", new { queueName = ViewBag.QueueName })';
         var payload = $('#ReceiveQueueForm').serialize();
-        $.post(receiveQueueUrl, payload)
-            .done(StartReceiveQueueSucceeded)
-            .fail(StartReceiveQueueFailed)
-            .always(StartReceiveQueueCompleted);
+        var ajaxRequest = $.post(receiveQueueUrl, payload)
+            .done(StartReceiveQueueSucceeded);
+
+        ajax.indicate(ajaxRequest, $('#ReceiveQueueAjaxStatus'));
 
         StartReceiveQueueStarted();
     }
@@ -22,42 +23,20 @@
     function StartReceiveQueueStarted() {
         // Disable the button so it cannot be double clicked, or more.
         $('#StartReceivingQueueButton').prop('disabled', true);
-
-        $('#AjaxStatus').text('STARTED');
-        $('#AjaxStatusMessage').text('Request submitted, awaiting a response from the server.');
     }
 
     function StartReceiveQueueSucceeded() {
-        $('#AjaxResult').text('SUCCEEDED');
-        $('#AjaxStatusMessage').text('Request accepted by server, the queue is now being received...');
-
         // Start polling for completion...
         setTimeout(PollReceiveStatus, 500);
-    }
-
-    function StartReceiveQueueFailed(response) {
-        $('#AjaxResult').text('FAILED');
-        $('#AjaxStatusMessage').text(response.responseText);
-    }
-
-    function StartReceiveQueueCompleted() {
-        $('#AjaxStatus').text('COMPLETED');
     }
 
     function PollReceiveStatus() {
         var receiveStatusUrl = '@Url.HttpRouteUrl("GetReceiveQueueStatus", new { queueName = ViewBag.QueueName })';
 
-        $.getJSON(receiveStatusUrl)
-            .done(UpdateReceiveStatus)
-            .fail(UpdateReceiveStatusFailed)
-            .always(UpdateReceiveStatusCompleted);
+        var ajaxRequest = $.getJSON(receiveStatusUrl)
+            .done(UpdateReceiveStatus);
 
-        GetReceiveQueueStatusStarted();
-    }
-
-    function GetReceiveQueueStatusStarted() {
-        $('#AjaxStatus').text('STARTED');
-        $('#AjaxStatusMessage').text('Request submitted, awaiting a response from the server.');
+        ajax.indicate(ajaxRequest, $('#ReceiveQueueAjaxStatus'));
     }
 
     function UpdateReceiveStatus(receiveOperation) {
@@ -86,17 +65,6 @@
 
         $('#ReceiveQueueMessagesReceived')
             .text(receiveOperation.ReceivedCount);
-    }
-
-    function UpdateReceiveStatusFailed(response) {
-        $('#AjaxResult').text('FAILED');
-        $('#AjaxStatusMessage').text(response.responseText);
-
-        alert(response.responseText);
-    }
-
-    function UpdateReceiveStatusCompleted() {
-        $('#AjaxStatus').text('COMPLETED');
     }
 
     $(function () {

--- a/Source/ExampleApp.Web/Views/Home/ReceiveQueue.cshtml
+++ b/Source/ExampleApp.Web/Views/Home/ReceiveQueue.cshtml
@@ -1,5 +1,7 @@
 ﻿@model ExampleApp.Web.Models.ReceiveQueueCommandModel
 
+<h2>Receive All Queued Messages</h2>
+
 <form id="ReceiveQueueForm">
     @Html.EditorForModel()
     <button id="StartReceivingQueueButton" type="button">Start</button>
@@ -14,7 +16,7 @@
         var ajaxRequest = $.post(receiveQueueUrl, payload)
             .done(StartReceiveQueueSucceeded);
 
-        ajax.indicate(ajaxRequest, $('#ReceiveQueueAjaxStatus'));
+        ajax.indicate(ajaxRequest, $('#ReceiveQueueAjaxStatus'), true);
 
         StartReceiveQueueStarted();
     }

--- a/Source/ExampleApp.Web/Views/Home/SendMessage.cshtml
+++ b/Source/ExampleApp.Web/Views/Home/SendMessage.cshtml
@@ -3,7 +3,7 @@
 <form id="SendMessageForm">
     @Html.EditorForModel()
     <button id="SendMessageButton" type="button">Send</button>
-    <div id="SendMessageAjaxStatus">?</div>
+    <div id="SendMessageAjaxStatus"></div>
 </form>
 
 <script type="text/javascript">

--- a/Source/ExampleApp.Web/Views/Home/SendMessage.cshtml
+++ b/Source/ExampleApp.Web/Views/Home/SendMessage.cshtml
@@ -3,6 +3,7 @@
 <form id="SendMessageForm">
     @Html.EditorForModel()
     <button id="SendMessageButton" type="button">Send</button>
+    <div id="SendMessageAjaxStatus">?</div>
 </form>
 
 <script type="text/javascript">
@@ -11,34 +12,19 @@
         // Disable the button so it cannot be double clicked, or more.
         $('#SendMessageButton').prop('disabled', true);
         $('#SendMessageButton').text('Sending...');
-
-        $('#AjaxStatus').text('STARTED');
-        $('#AjaxStatusMessage').text('Request submitting, awaiting a response from the server.');
-    }
-
-    function SendMessageSucceeded() {
-        $('#AjaxResult').text('SUCCEEDED');
-        $('#AjaxStatusMessage').text('The last request was successful.');
-    }
-
-    function SendMessageFailed(response) {
-        $('#AjaxResult').text('FAILED');
-        $('#AjaxStatusMessage').text(response.responseText);
     }
 
     function SendMessageCompleted() {
         $('#SendMessageButton')
             .prop('disabled', false)
             .text('Send');
-
-        $('#AjaxStatus').text('COMPLETED');
     }
 
     function SendMessage() {
-        $.post('@Url.HttpRouteUrl("SendMessage", new { queueName = ViewBag.QueueName })', $('#SendMessageForm').serialize())
-            .done(SendMessageSucceeded)
-            .fail(SendMessageFailed)
+        var ajaxRequest = $.post('@Url.HttpRouteUrl("SendMessage", new { queueName = ViewBag.QueueName })', $('#SendMessageForm').serialize())
             .always(SendMessageCompleted);
+
+        ajax.indicate(ajaxRequest, $('#SendMessageAjaxStatus'));
 
         SendMessageStarted();
     }

--- a/Source/ExampleApp.Web/Views/Home/SendMessage.cshtml
+++ b/Source/ExampleApp.Web/Views/Home/SendMessage.cshtml
@@ -1,5 +1,7 @@
 ﻿@model ExampleApp.Web.Models.SendMessageCommandModel
 
+<h2>Enqueue a Message</h2>
+
 <form id="SendMessageForm">
     @Html.EditorForModel()
     <button id="SendMessageButton" type="button">Send</button>
@@ -24,7 +26,7 @@
         var ajaxRequest = $.post('@Url.HttpRouteUrl("SendMessage", new { queueName = ViewBag.QueueName })', $('#SendMessageForm').serialize())
             .always(SendMessageCompleted);
 
-        ajax.indicate(ajaxRequest, $('#SendMessageAjaxStatus'));
+        ajax.indicate(ajaxRequest, $('#SendMessageAjaxStatus'), true);
 
         SendMessageStarted();
     }

--- a/Source/ExampleApp.Web/Views/Shared/_Layout.cshtml
+++ b/Source/ExampleApp.Web/Views/Shared/_Layout.cshtml
@@ -8,6 +8,7 @@
     @Styles.Render("~/Content/css")
     @Scripts.Render("~/bundles/jquery")
     @Scripts.Render("~/bundles/modernizr")
+    @Scripts.Render("~/bundles/slinqy")
 </head>
 <body>
     <div class="container body-content">

--- a/Source/Slinqy.Test.Functional/Models/ExampleAppPages/AjaxIndicatorSection.cs
+++ b/Source/Slinqy.Test.Functional/Models/ExampleAppPages/AjaxIndicatorSection.cs
@@ -1,0 +1,76 @@
+﻿namespace Slinqy.Test.Functional.Models.ExampleAppPages
+{
+    using System;
+    using System.Linq;
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Support.UI;
+
+    /// <summary>
+    /// Models the ajax indicator widget.
+    /// </summary>
+    public class AjaxIndicatorSection : SeleniumWebBase
+    {
+        /// <summary>
+        /// The proxy reference to the ajax indicator element on the web page.
+        /// </summary>
+        private readonly IWebElement ajaxStatusElement;
+
+        /// <summary>
+        /// The CSS ID of the AJAX Status Element.
+        /// </summary>
+        private readonly string ajaxStatusElementId;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AjaxIndicatorSection"/> class.
+        /// </summary>
+        /// <param name="webBrowserDriver">Specifies the web driver to use for interacting with the web browser.</param>
+        /// <param name="ajaxStatusElement">Specifies the element where the AJAX status will be rendered.</param>
+        public
+        AjaxIndicatorSection(
+            IWebDriver  webBrowserDriver,
+            IWebElement ajaxStatusElement)
+            : base(webBrowserDriver)
+        {
+            if (ajaxStatusElement == null)
+                throw new ArgumentNullException(nameof(ajaxStatusElement));
+
+            this.ajaxStatusElement = ajaxStatusElement;
+            this.ajaxStatusElementId = ajaxStatusElement.GetAttribute("id");
+        }
+
+        /// <summary>
+        /// Waits for the indicator to report the result of the AJAX request.
+        /// </summary>
+        /// <param name="maxDuration">
+        /// Specifies how long to wait before timing out.
+        /// </param>
+        public
+        void
+        WaitForResult(
+            TimeSpan maxDuration)
+        {
+            new WebDriverWait(
+                this.WebBrowserDriver,
+                maxDuration
+            ).Until(
+                driver =>
+                {
+                    var statusStillExists = driver.FindElements(
+                        By.Id(this.ajaxStatusElementId)
+                    ).Any(); // The status element is no longer on the page.
+
+                    if (!statusStillExists)
+                        return true;
+
+                    var statusClass = this.ajaxStatusElement.GetAttribute("class");
+
+                    if (statusClass.Contains("ajax-failed"))
+                        throw new InvalidOperationException(this.ajaxStatusElement.Text);
+
+                    return !statusClass.Contains("ajax-running");
+                }
+
+            );
+        }
+    }
+}

--- a/Source/Slinqy.Test.Functional/Models/ExampleAppPages/CreateQueueForm.cs
+++ b/Source/Slinqy.Test.Functional/Models/ExampleAppPages/CreateQueueForm.cs
@@ -4,7 +4,6 @@
     using System.Globalization;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Support.PageObjects;
-    using Utilities.Polling;
     using Utilities.Strings;
 
     /// <summary>
@@ -12,6 +11,11 @@
     /// </summary>
     public class CreateQueueForm : SeleniumWebBase
     {
+        /// <summary>
+        /// The proxy reference to the AJAX request result message element on the web page.
+        /// </summary>
+        private readonly AjaxIndicatorSection createQueueAjaxStatusSection;
+
         /// <summary>
         /// The proxy reference to the queue name input on the web page.
         /// </summary>
@@ -37,22 +41,10 @@
         private IWebElement createQueueButton = null;
 
         /// <summary>
-        /// The proxy reference to the AJAX request status element on the web page.
-        /// </summary>
-        [FindsBy(How = How.Id, Using = "AjaxStatus")]
-        private IWebElement ajaxStatus = null;
-
-        /// <summary>
-        /// The proxy reference to the AJAX request result element on the web page.
-        /// </summary>
-        [FindsBy(How = How.Id, Using = "AjaxResult")]
-        private IWebElement ajaxResult = null;
-
-        /// <summary>
         /// The proxy reference to the AJAX request result message element on the web page.
         /// </summary>
-        [FindsBy(How = How.Id, Using = "AjaxStatusMessage")]
-        private IWebElement ajaxStatusMessage = null;
+        [FindsBy(How = How.Id, Using = "CreateQueueAjaxStatus")]
+        private IWebElement createQueueAjaxStatusSectionElement = null;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CreateQueueForm"/> class.
@@ -65,6 +57,10 @@
             IWebDriver webBrowserDriver)
                 : base(webBrowserDriver)
         {
+            this.createQueueAjaxStatusSection = new AjaxIndicatorSection(
+                webBrowserDriver,
+                this.createQueueAjaxStatusSectionElement
+            );
         }
 
         /// <summary>
@@ -113,16 +109,7 @@
             this.createQueueButton.Click();
 
             // Wait for it to finish
-            Poll.Value(
-                from:               ()   => this.ajaxStatus.Text,
-                until:              text => text != "COMPLETED",
-                maxDuration:    TimeSpan.FromSeconds(15),
-                interval:           TimeSpan.FromMilliseconds(500)
-            );
-
-            // Check the result
-            if (this.ajaxResult.Text == "FAILED")
-                throw new InvalidOperationException(this.ajaxStatusMessage.Text);
+            this.createQueueAjaxStatusSection.WaitForResult(maxDuration: TimeSpan.FromSeconds(15));
 
             // Return queue info
             return new ManageQueueSection(this.WebBrowserDriver);

--- a/Source/Slinqy.Test.Functional/Models/ExampleAppPages/QueueClientSection.cs
+++ b/Source/Slinqy.Test.Functional/Models/ExampleAppPages/QueueClientSection.cs
@@ -13,6 +13,11 @@
     public class QueueClientSection : SeleniumWebBase
     {
         /// <summary>
+        /// The proxy reference to the AJAX request result message element on the web page.
+        /// </summary>
+        private readonly AjaxIndicatorSection fillQueueAjaxStatusSection;
+
+        /// <summary>
         /// A proxy reference to the element in the web browser.
         /// </summary>
         /// <remarks>This field is automatically populated by SpecFlow.</remarks>
@@ -76,6 +81,12 @@
         private IWebElement receivedMessageBody = null;
 
         /// <summary>
+        /// The proxy reference to the AJAX request result message element on the web page.
+        /// </summary>
+        [FindsBy(How = How.Id, Using = "FillQueueStatusAjaxStatus")]
+        private IWebElement fillQueueStatusAjaxStatusSectionElement = null;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="QueueClientSection"/> class.
         /// </summary>
         /// <param name="webBrowserDriver">Specifies the driver to use for interacting with the web browser.</param>
@@ -84,6 +95,10 @@
             IWebDriver webBrowserDriver)
                 : base(webBrowserDriver)
         {
+            this.fillQueueAjaxStatusSection = new AjaxIndicatorSection(
+                webBrowserDriver,
+                this.fillQueueStatusAjaxStatusSectionElement
+            );
         }
 
         /// <summary>
@@ -111,7 +126,10 @@
 
             this.fillQueueButton.Click();
 
-            // Wait for it to finish
+            // Wait for the fill request to start or fail.
+            this.fillQueueAjaxStatusSection.WaitForResult(TimeSpan.FromSeconds(15));
+
+            // Wait for the fill to finish.
             Poll.Value(
                 from:           () => this.fillQueueButton.Enabled,
                 until:          enabled => enabled,

--- a/Source/Slinqy.Test.Functional/Models/ExampleAppPages/QueueClientSection.cs
+++ b/Source/Slinqy.Test.Functional/Models/ExampleAppPages/QueueClientSection.cs
@@ -18,6 +18,11 @@
         private readonly AjaxIndicatorSection fillQueueAjaxStatusSection;
 
         /// <summary>
+        /// The proxy reference to the AJAX request result message element on the web page.
+        /// </summary>
+        private readonly AjaxIndicatorSection sendMessageAjaxStatusSection;
+
+        /// <summary>
         /// A proxy reference to the element in the web browser.
         /// </summary>
         /// <remarks>This field is automatically populated by SpecFlow.</remarks>
@@ -87,6 +92,12 @@
         private IWebElement fillQueueStatusAjaxStatusSectionElement = null;
 
         /// <summary>
+        /// The proxy reference to the AJAX request result message element on the web page.
+        /// </summary>
+        [FindsBy(How = How.Id, Using = "SendMessageAjaxStatus")]
+        private IWebElement sendMessageAjaxStatusSectionElement = null;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="QueueClientSection"/> class.
         /// </summary>
         /// <param name="webBrowserDriver">Specifies the driver to use for interacting with the web browser.</param>
@@ -98,6 +109,11 @@
             this.fillQueueAjaxStatusSection = new AjaxIndicatorSection(
                 webBrowserDriver,
                 this.fillQueueStatusAjaxStatusSectionElement
+            );
+
+            this.sendMessageAjaxStatusSection = new AjaxIndicatorSection(
+                webBrowserDriver,
+                this.sendMessageAjaxStatusSectionElement
             );
         }
 
@@ -178,12 +194,7 @@
             this.sendMessageButton.Click();
 
             // Wait for it to finish
-            Poll.Value(
-                from:           () => this.sendMessageButton.Enabled,
-                until:          enabled => enabled,
-                interval:       TimeSpan.FromMilliseconds(500),
-                maxDuration:    TimeSpan.FromSeconds(15)
-            );
+            this.sendMessageAjaxStatusSection.WaitForResult(TimeSpan.FromSeconds(15));
 
             return randomMessage;
         }

--- a/Source/Slinqy.Test.Functional/Models/ExampleAppPages/QueueClientSection.cs
+++ b/Source/Slinqy.Test.Functional/Models/ExampleAppPages/QueueClientSection.cs
@@ -23,6 +23,11 @@
         private readonly AjaxIndicatorSection sendMessageAjaxStatusSection;
 
         /// <summary>
+        /// The proxy reference to the AJAX request result message element on the web page.
+        /// </summary>
+        private readonly AjaxIndicatorSection receiveMessageAjaxStatusSection;
+
+        /// <summary>
         /// A proxy reference to the element in the web browser.
         /// </summary>
         /// <remarks>This field is automatically populated by SpecFlow.</remarks>
@@ -98,6 +103,12 @@
         private IWebElement sendMessageAjaxStatusSectionElement = null;
 
         /// <summary>
+        /// The proxy reference to the AJAX request result message element on the web page.
+        /// </summary>
+        [FindsBy(How = How.Id, Using = "ReceiveMessageAjaxStatus")]
+        private IWebElement receiveMessageAjaxStatusSectionElement = null;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="QueueClientSection"/> class.
         /// </summary>
         /// <param name="webBrowserDriver">Specifies the driver to use for interacting with the web browser.</param>
@@ -114,6 +125,11 @@
             this.sendMessageAjaxStatusSection = new AjaxIndicatorSection(
                 webBrowserDriver,
                 this.sendMessageAjaxStatusSectionElement
+            );
+
+            this.receiveMessageAjaxStatusSection = new AjaxIndicatorSection(
+                webBrowserDriver,
+                this.receiveMessageAjaxStatusSectionElement
             );
         }
 
@@ -210,12 +226,7 @@
             this.receiveMessageButton.Click();
 
             // Wait for it to finish
-            Poll.Value(
-                from:           () => this.receivedMessageBody.Text,
-                until:          body => !string.IsNullOrWhiteSpace(body),
-                interval:       TimeSpan.FromMilliseconds(500),
-                maxDuration:    TimeSpan.FromSeconds(15)
-            );
+            this.receiveMessageAjaxStatusSection.WaitForResult(TimeSpan.FromSeconds(15));
 
             return this.receivedMessageBody.Text;
         }

--- a/Source/Slinqy.Test.Functional/Models/ExampleAppPages/QueueClientSection.cs
+++ b/Source/Slinqy.Test.Functional/Models/ExampleAppPages/QueueClientSection.cs
@@ -28,6 +28,11 @@
         private readonly AjaxIndicatorSection receiveMessageAjaxStatusSection;
 
         /// <summary>
+        /// The proxy reference to the AJAX request result message element on the web page.
+        /// </summary>
+        private readonly AjaxIndicatorSection receiveQueueAjaxStatusSection;
+
+        /// <summary>
         /// A proxy reference to the element in the web browser.
         /// </summary>
         /// <remarks>This field is automatically populated by SpecFlow.</remarks>
@@ -109,6 +114,12 @@
         private IWebElement receiveMessageAjaxStatusSectionElement = null;
 
         /// <summary>
+        /// The proxy reference to the AJAX request result message element on the web page.
+        /// </summary>
+        [FindsBy(How = How.Id, Using = "ReceiveQueueAjaxStatus")]
+        private IWebElement receiveQueueAjaxStatusSectionElement = null;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="QueueClientSection"/> class.
         /// </summary>
         /// <param name="webBrowserDriver">Specifies the driver to use for interacting with the web browser.</param>
@@ -130,6 +141,11 @@
             this.receiveMessageAjaxStatusSection = new AjaxIndicatorSection(
                 webBrowserDriver,
                 this.receiveMessageAjaxStatusSectionElement
+            );
+
+            this.receiveQueueAjaxStatusSection = new AjaxIndicatorSection(
+                webBrowserDriver,
+                this.receiveQueueAjaxStatusSectionElement
             );
         }
 
@@ -183,7 +199,10 @@
         {
             this.receiveQueueButton.Click();
 
-            // Wait for it to finish
+            // Wait for the receive queue request to start or fail.
+            this.receiveQueueAjaxStatusSection.WaitForResult(TimeSpan.FromSeconds(15));
+
+            // Wait for the receive to finish.
             Poll.Value(
                 from:           () => this.receiveQueueButton.Enabled,
                 until:          enabled => enabled,

--- a/Source/Slinqy.Test.Functional/Setup.cs
+++ b/Source/Slinqy.Test.Functional/Setup.cs
@@ -57,7 +57,7 @@
                 .Manage()
                 .Timeouts()
                 .ImplicitlyWait(
-                    TimeSpan.FromSeconds(10)
+                    TimeSpan.FromSeconds(5)
                 );
 
             this.objectContainer.RegisterInstanceAs(this.webBrowser);

--- a/Source/Slinqy.Test.Functional/Slinqy.Test.Functional.csproj
+++ b/Source/Slinqy.Test.Functional/Slinqy.Test.Functional.csproj
@@ -108,6 +108,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>SendQueueMessages.feature</DependentUpon>
     </Compile>
+    <Compile Include="Models\ExampleAppPages\AjaxIndicatorSection.cs" />
     <Compile Include="Models\ExampleAppPages\CreateQueueForm.cs">
       <ExcludeFromStyleCop>False</ExcludeFromStyleCop>
     </Compile>


### PR DESCRIPTION
Consolidates all the AJAX status code for reporting status to the user that was duplicated across all the partial views.

Now there's a simple re-usable component called ajax.indicate located in the new Source/ExampleApp.Web/Scripts/ajax.indicator.js

It can indicate four states:
- Running
- Succeeded
- Failed
- Completed

Failures during functional testing will be better and more consistently reported via test output now as well making developing\troubleshooting significantly easier.