### PR TITLE
Replaces Object or String Queue Message Return Types with Generics

### DIFF
--- a/Source/ExampleApp.Web/Controllers/SlinqyQueueController.cs
+++ b/Source/ExampleApp.Web/Controllers/SlinqyQueueController.cs
@@ -330,7 +330,7 @@
                 {
                     // Receive the batch of messages.
                     var maxWaitTimeSpan = TimeSpan.FromSeconds(1);
-                    var receivedBatch   = await queue.ReceiveBatch(maxWaitTimeSpan)
+                    var receivedBatch   = await queue.ReceiveBatch<byte[]>(maxWaitTimeSpan)
                         .ConfigureAwait(false);
 
                     ReceiveOperations[queueName]

--- a/Source/ExampleApp.Web/Controllers/SlinqyQueueController.cs
+++ b/Source/ExampleApp.Web/Controllers/SlinqyQueueController.cs
@@ -250,7 +250,7 @@
             var queue = SlinqyQueueClient.Get(queueName);
 
             return await queue
-                .Receive()
+                .Receive<string>()
                 .ConfigureAwait(false);
         }
 

--- a/Source/ExampleApp.Web/Models/ServiceBusQueueModel.cs
+++ b/Source/ExampleApp.Web/Models/ServiceBusQueueModel.cs
@@ -96,17 +96,18 @@
         /// Receives a batch of messages from the queue in a single transaction.
         /// </summary>
         /// <param name="maxWaitTime">Specifies the maximum amount of time to wait for messages before returning.</param>
+        /// <typeparam name="T">Specifies the Type that is expected to return.</typeparam>
         /// <returns>Returns an enumeration of the messages that were received.</returns>
         public
-        async Task<IEnumerable<object>>
-        ReceiveBatch(
+        async Task<IEnumerable<T>>
+        ReceiveBatch<T>(
             TimeSpan maxWaitTime)
         {
             var batch = await this.queueClient
                 .ReceiveBatchAsync(messageCount: 100, serverWaitTime: maxWaitTime)
                 .ConfigureAwait(false);
 
-            return batch.Select(message => (object)message);
+            return batch.Select(message => message.GetBody<T>());
         }
 
         /// <summary>

--- a/Source/ExampleApp.Web/Models/ServiceBusQueueModel.cs
+++ b/Source/ExampleApp.Web/Models/ServiceBusQueueModel.cs
@@ -83,13 +83,13 @@
         /// </param>
         /// <returns>Returns an async Task for the work.</returns>
         public
-        Task
+        async Task
         SendBatch(
             IEnumerable<object> batch)
         {
-            return this.queueClient.SendBatchAsync(
-                batch.Select(o => new BrokeredMessage(o))
-            );
+            await this.queueClient
+                .SendBatchAsync(batch.Select(o => new BrokeredMessage(o)))
+                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -117,7 +117,7 @@
         public
         async Task
         Send(
-            string messageBody)
+            object messageBody)
         {
             await this.queueClient
                 .SendAsync(new BrokeredMessage(messageBody))
@@ -127,16 +127,17 @@
         /// <summary>
         /// Receives the next message from the queue.
         /// </summary>
+        /// <typeparam name="T">Specifies the Type that is expected to return.</typeparam>
         /// <returns>The body of the message that was received.</returns>
         public
-        async Task<string>
-        Receive()
+        async Task<T>
+        Receive<T>()
         {
             var message = await this.queueClient
                 .ReceiveAsync()
                 .ConfigureAwait(false);
 
-            return message.GetBody<string>();
+            return message.GetBody<T>();
         }
     }
 }

--- a/Source/Slinqy.Core.Test.Unit/SlinqyQueueShardTests.cs
+++ b/Source/Slinqy.Core.Test.Unit/SlinqyQueueShardTests.cs
@@ -214,11 +214,11 @@
         {
             // Arrange
             // Act
-            await this.slinqyQueueShard.Receive();
+            await this.slinqyQueueShard.Receive<string>();
 
             // Assert
             A.CallTo(() =>
-                this.fakePhysicalQueue.Receive()
+                this.fakePhysicalQueue.Receive<string>()
             ).MustHaveHappened();
         }
 

--- a/Source/Slinqy.Core.Test.Unit/SlinqyQueueShardTests.cs
+++ b/Source/Slinqy.Core.Test.Unit/SlinqyQueueShardTests.cs
@@ -233,11 +233,11 @@
         {
             // Arrange
             // Act
-            await this.slinqyQueueShard.ReceiveBatch(this.validMaxWaitTimeSpan);
+            await this.slinqyQueueShard.ReceiveBatch<object>(this.validMaxWaitTimeSpan);
 
             // Assert
             A.CallTo(() =>
-                this.fakePhysicalQueue.ReceiveBatch(A<TimeSpan>.Ignored)
+                this.fakePhysicalQueue.ReceiveBatch<object>(A<TimeSpan>.Ignored)
             ).MustHaveHappened();
         }
 

--- a/Source/Slinqy.Core.Test.Unit/SlinqyQueueTests.cs
+++ b/Source/Slinqy.Core.Test.Unit/SlinqyQueueTests.cs
@@ -173,11 +173,11 @@
         {
             // Arrange
             // Act
-            await this.slinqyQueue.Receive();
+            await this.slinqyQueue.Receive<string>();
 
             // Assert
             A.CallTo(() =>
-                this.fakeReceiveShard.Receive()
+                this.fakeReceiveShard.Receive<string>()
             ).MustHaveHappened();
         }
     }

--- a/Source/Slinqy.Core.Test.Unit/SlinqyQueueTests.cs
+++ b/Source/Slinqy.Core.Test.Unit/SlinqyQueueTests.cs
@@ -154,11 +154,11 @@
         {
             // Arrange
             // Act
-            await this.slinqyQueue.ReceiveBatch(this.validMaxWaitTimeSpan);
+            await this.slinqyQueue.ReceiveBatch<object>(this.validMaxWaitTimeSpan);
 
             // Assert
             A.CallTo(() =>
-                this.fakeReceiveShard.ReceiveBatch(A<TimeSpan>.Ignored)
+                this.fakeReceiveShard.ReceiveBatch<object>(A<TimeSpan>.Ignored)
             ).MustHaveHappened();
         }
 

--- a/Source/Slinqy.Core/IPhysicalQueue.cs
+++ b/Source/Slinqy.Core/IPhysicalQueue.cs
@@ -49,9 +49,10 @@
         /// Receives a batch of messages from the queue.
         /// </summary>
         /// <param name="maxWaitTime">Specifies the maximum amount of time to wait for messages before returning.</param>
+        /// <typeparam name="T">Specifies the Type that is expected to return.</typeparam>
         /// <returns>Returns an enumeration of messages that were received.</returns>
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "This rule wasn't designed for async Tasks.")]
-        Task<IEnumerable<object>> ReceiveBatch(TimeSpan maxWaitTime);
+        Task<IEnumerable<T>> ReceiveBatch<T>(TimeSpan maxWaitTime);
 
         /// <summary>
         /// Sends a message to the queue.

--- a/Source/Slinqy.Core/IPhysicalQueue.cs
+++ b/Source/Slinqy.Core/IPhysicalQueue.cs
@@ -58,12 +58,13 @@
         /// </summary>
         /// <param name="messageBody">Specifies the body of the message.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task Send(string messageBody); // TODO: Should be: Task Send(object messageBody)
+        Task Send(object messageBody);
 
         /// <summary>
         /// Receives the next message from the queue.
         /// </summary>
+        /// <typeparam name="T">Specifies the Type that is expected to return.</typeparam>
         /// <returns>The body of the message that was received.</returns>
-        Task<string> Receive();
+        Task<T> Receive<T>();
     }
 }

--- a/Source/Slinqy.Core/SlinqyQueue.cs
+++ b/Source/Slinqy.Core/SlinqyQueue.cs
@@ -95,12 +95,15 @@
         /// <summary>
         /// Receives the next message from the queue.
         /// </summary>
+        /// <typeparam name="T">Specifies the Type that is expected to return.</typeparam>
         /// <returns>Returns the body of the message that was received.</returns>
         public
-        async Task<string>
-        Receive()
+        async Task<T>
+        Receive<T>()
         {
-            return await this.queueShardMonitor.ReceiveShard.Receive();
+            return await this.queueShardMonitor
+                .ReceiveShard
+                .Receive<T>();
         }
     }
 }

--- a/Source/Slinqy.Core/SlinqyQueue.cs
+++ b/Source/Slinqy.Core/SlinqyQueue.cs
@@ -63,16 +63,17 @@
         /// Retrieves the next batch of messages from the queue.
         /// </summary>
         /// <param name="maxWaitTime">Specifies the maximum amount of time to wait for messages before returning.</param>
+        /// <typeparam name="T">Specifies the Type that is expected to return.</typeparam>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "This rule wasn't designed for async Tasks.")]
         public
-        async Task<IEnumerable<object>>
-        ReceiveBatch(
+        async Task<IEnumerable<T>>
+        ReceiveBatch<T>(
             TimeSpan maxWaitTime)
         {
             return await this.queueShardMonitor
                 .ReceiveShard
-                .ReceiveBatch(maxWaitTime)
+                .ReceiveBatch<T>(maxWaitTime)
                 .ConfigureAwait(false);
         }
 

--- a/Source/Slinqy.Core/SlinqyQueueShard.cs
+++ b/Source/Slinqy.Core/SlinqyQueueShard.cs
@@ -165,16 +165,17 @@
         /// Receives a batch of messages from the queue.
         /// </summary>
         /// <param name="maxWaitTime">Specifies the maximum amount of time to wait for messages before returning.</param>
+        /// <typeparam name="T">Specifies the Type that is expected to return.</typeparam>
         /// <returns>Returns an enumeration of messages that were received.</returns>
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "This rule wasn't designed for async Tasks.")]
         public
         virtual
-        async Task<IEnumerable<object>>
-        ReceiveBatch(
+        async Task<IEnumerable<T>>
+        ReceiveBatch<T>(
             TimeSpan maxWaitTime)
         {
             return await this.PhysicalQueue
-                .ReceiveBatch(maxWaitTime)
+                .ReceiveBatch<T>(maxWaitTime)
                 .ConfigureAwait(false);
         }
 

--- a/Source/Slinqy.Core/SlinqyQueueShard.cs
+++ b/Source/Slinqy.Core/SlinqyQueueShard.cs
@@ -197,14 +197,15 @@
         /// <summary>
         /// Receives the next message from the queue.
         /// </summary>
+        /// <typeparam name="T">Specifies the Type that is expected to return.</typeparam>
         /// <returns>Returns the body of the message that was received.</returns>
         public
         virtual
-        async Task<string>
-        Receive()
+        async Task<T>
+        Receive<T>()
         {
             return await this.PhysicalQueue
-                .Receive()
+                .Receive<T>()
                 .ConfigureAwait(false);
         }
 


### PR DESCRIPTION
Updates the Receive and ReceiveBatch methods to take a Type parameter allowing the user to specify what Type is expected to be returned from the queue so they don't have to cast or convert afterward.