### PR TITLE
Take Screenshot on Test Failure

### DIFF
--- a/Source/Slinqy.Test.Functional/Setup.cs
+++ b/Source/Slinqy.Test.Functional/Setup.cs
@@ -83,11 +83,16 @@
 
             const string ScreenshotDirectoryName = "Screenshots";
 
-            if (!Directory.Exists(ScreenshotDirectoryName))
-                Directory.CreateDirectory(ScreenshotDirectoryName);
+            var screenshotsPath = Path.Combine(
+                Environment.CurrentDirectory,
+                ScreenshotDirectoryName
+            );
+
+            if (!Directory.Exists(screenshotsPath))
+                Directory.CreateDirectory(screenshotsPath);
 
             var screenshotPath = Path.Combine(
-                ScreenshotDirectoryName,
+                screenshotsPath,
                 failedTestName + " - Failure.png"
             );
 

--- a/Source/Slinqy.Test.Functional/Setup.cs
+++ b/Source/Slinqy.Test.Functional/Setup.cs
@@ -97,6 +97,9 @@
             );
 
             screenshot.SaveAsFile(screenshotPath, ImageFormat.Png);
+
+            // TODO: Temporary, remove!
+            throw new AggregateException("Saved to " + screenshotPath);
         }
 
         /// <summary>

--- a/Source/Slinqy.Test.Functional/Setup.cs
+++ b/Source/Slinqy.Test.Functional/Setup.cs
@@ -97,9 +97,6 @@
             );
 
             screenshot.SaveAsFile(screenshotPath, ImageFormat.Png);
-
-            // TODO: Temporary, remove!
-            throw new AggregateException("Saved to " + screenshotPath);
         }
 
         /// <summary>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,5 +18,5 @@ cache:
   - .\Source\packages -> .\Source\ExampleApp.Web\packages.config
   - C:\Users\appveyor\AppData\Roaming\Windows Azure Powershell\AzureDataCollectionProfile.json
 
-artifacts:
-  - path: .\Artifacts
+on_failure:
+  - ps: if (Test-Path .\Artifacts\Screenshots) { Get-ChildItem .\Artifacts\Screenshots | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name } }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,4 +19,4 @@ cache:
   - C:\Users\appveyor\AppData\Roaming\Windows Azure Powershell\AzureDataCollectionProfile.json
 
 artifacts:
-  - path: .\Artifacts\Screenshots
+  - path: .\Artifacts


### PR DESCRIPTION
Modifies CI to capture screenshot of the Web Browser when an integration test fails so that it can be more easily investigated when a test fails in the CI server.